### PR TITLE
fix(evals): StepEfficiency negative score on redundant calls within a step

### DIFF
--- a/python/fi/evals/metrics/agents/metrics.py
+++ b/python/fi/evals/metrics/agents/metrics.py
@@ -249,7 +249,8 @@ class StepEfficiency(BaseMetric[AgentTrajectoryInput]):
                 else:
                     seen_signatures.add(call_sig)
 
-        redundancy_ratio = 1.0 - (redundant_count / total_steps) if total_steps > 0 else 1.0
+        total_calls = sum(len(step.tool_calls) for step in inputs.trajectory)
+        redundancy_ratio = 1.0 - (redundant_count / total_calls) if total_calls > 0 else 1.0
         redundancy_score = redundancy_ratio * self.redundancy_weight
         details["redundant_steps"] = redundant_count
 
@@ -259,7 +260,6 @@ class StepEfficiency(BaseMetric[AgentTrajectoryInput]):
             for tc in step.tool_calls
             if not tc.success
         )
-        total_calls = sum(len(step.tool_calls) for step in inputs.trajectory)
         failure_ratio = 1.0 - (failed_calls / total_calls) if total_calls > 0 else 1.0
         failure_score = failure_ratio * self.failure_weight
         details["failed_calls"] = failed_calls

--- a/python/tests/sdk/test_agents.py
+++ b/python/tests/sdk/test_agents.py
@@ -164,6 +164,31 @@ class TestStepEfficiency:
         result = metric.compute_one(input_data)
         assert result["details"]["redundant_steps"] >= 3
 
+    def test_redundant_calls_within_single_step(self):
+        """Multiple redundant calls in one step must not push the score below 0."""
+        metric = StepEfficiency()
+        step = AgentStep(
+            step_number=1,
+            thought="Repeating the same call",
+            tool_calls=[
+                ToolCall(
+                    name="search",
+                    arguments={"query": "test"},
+                    result="result",
+                    success=True,
+                )
+                for _ in range(5)
+            ],
+            is_final=True,
+        )
+        input_data = AgentTrajectoryInput(
+            trajectory=[step],
+            task=TaskDefinition(description="Search for something")
+        )
+        result = metric.compute_one(input_data)
+        assert 0.0 <= result["output"] <= 1.0
+        assert result["details"]["redundant_steps"] == 4
+
     def test_failed_tool_calls(self):
         """Test trajectory with failed tool calls."""
         metric = StepEfficiency()


### PR DESCRIPTION
Fixes #60

## What does this PR do?

Fixes StepEfficiency returning a negative score when a single trajectory step contains more than one redundant tool call.

## Why?

Redundancy was counted per tool call (the inner loop runs over step.tool_calls) but the ratio divided that count by total_steps, the number of steps. When a step makes several redundant calls, redundant_count exceeds total_steps, so redundancy_ratio goes below 0 and the final score drops out of the documented 0 to 1 range. On the reproduction in #60 (one step, five identical calls) the metric returned -0.2.

## What changed?

The redundancy ratio now divides by total_calls instead of total_steps, matching the failure calculation in the same method. total_calls is moved up so it is defined once before both uses. As discussed in #60, the per-call denominator keeps the ratio bounded by construction, so no clamp is added.

## Tests

Adds test_redundant_calls_within_single_step, covering multiple redundant calls within a single step and asserting the score stays within 0 to 1. The existing single-call-per-step test is unchanged. Full agent suite passes locally (29 passed).