### PR TITLE
Separate hosted simulator and agent credentials

### DIFF
--- a/src/fi/alk/harness/bundle_v2.py
+++ b/src/fi/alk/harness/bundle_v2.py
@@ -111,6 +111,7 @@ class ProcessUser(str, Enum):
 
 class SecretPurpose(str, Enum):
     TARGET_PROVIDER = "target_provider"
+    SIMULATOR_PROVIDER = "simulator_provider"
     SOURCE_CHECKOUT = "source_checkout"
 
 

--- a/src/fi/alk/harness/call_runner.py
+++ b/src/fi/alk/harness/call_runner.py
@@ -35,7 +35,7 @@ import logging
 import os
 import stat
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Protocol
@@ -52,7 +52,7 @@ from .background_noise import scenario_source
 from .bundle_v2 import EvidenceSeam
 from .hosted_scheduler import CallAborted, CallOutcome
 from .hosted_scheduler import Scenario as HostedScenario
-from .job import HarnessJob
+from .job import ExecutionMode, HarnessJob
 from .outbound import ArtifactKind, format_rfc3339_millis
 from .process_runtime import EnvironmentRuntime
 from .simulator_voice import (
@@ -91,6 +91,20 @@ SIMULATOR_TTS_PROVIDER_ALIAS = "SIMULATOR_TTS_PROVIDER"
 SIMULATOR_TTS_MODEL_ALIAS = "SIMULATOR_TTS_MODEL"
 LIVEKIT_URL_CONFIG_KEY = "livekit_url"
 CALL_TIMEOUT_CONFIG_KEY = "voice_call_timeout_seconds"
+
+_SIMULATOR_PLATFORM_ALIAS_MAP = {
+    "SIMULATOR_DEEPGRAM_API_KEY": DEEPGRAM_API_KEY_ALIAS,
+    "SIMULATOR_CARTESIA_API_KEY": CARTESIA_API_KEY_ALIAS,
+    "SIMULATOR_GEMINI_API_KEY": GEMINI_API_KEY_ALIAS,
+    "SIMULATOR_GOOGLE_API_KEY": GOOGLE_API_KEY_ALIAS,
+    "SIMULATOR_GOOGLE_APPLICATION_CREDENTIALS_JSON": (
+        GOOGLE_APPLICATION_CREDENTIALS_JSON_ALIAS
+    ),
+    "SIMULATOR_GOOGLE_CLOUD_PROJECT": GOOGLE_CLOUD_PROJECT_ALIAS,
+    "SIMULATOR_GOOGLE_CLOUD_LOCATION": GOOGLE_CLOUD_LOCATION_ALIAS,
+    "SIMULATOR_GOOGLE_GENAI_USE_VERTEXAI": GOOGLE_GENAI_USE_VERTEXAI_ALIAS,
+    "SIMULATOR_OPENAI_API_KEY": OPENAI_API_KEY_ALIAS,
+}
 
 _DEFAULT_CALL_TIMEOUT_SECONDS = 300.0
 
@@ -159,6 +173,7 @@ class CallRunnerContext:
     target_provider_secret_values: Mapping[str, str]
     attempt_number: int
     source_directory: Path | None = None
+    simulator_provider_secret_values: Mapping[str, str] = field(default_factory=dict)
 
 
 # --- pre-dial validation -----------------------------------------------------------------------
@@ -179,22 +194,24 @@ class _MissingVoiceConfig:
 
 
 def _check_config(
-    job: HarnessJob, target_provider_secret_values: Mapping[str, str]
+    job: HarnessJob,
+    target_provider_secret_values: Mapping[str, str],
+    simulator_provider_secret_values: Mapping[str, str],
 ) -> _MissingVoiceConfig | None:
     config = job.agent.config
     llm_provider = str(
         config.get("simulator_llm_provider")
-        or target_provider_secret_values.get(SIMULATOR_LLM_PROVIDER_ALIAS)
+        or simulator_provider_secret_values.get(SIMULATOR_LLM_PROVIDER_ALIAS)
         or "google"
     ).lower()
     stt_provider = str(
         config.get("simulator_stt_provider")
-        or target_provider_secret_values.get(SIMULATOR_STT_PROVIDER_ALIAS)
+        or simulator_provider_secret_values.get(SIMULATOR_STT_PROVIDER_ALIAS)
         or "deepgram"
     ).lower()
     tts_provider = str(
         config.get("simulator_tts_provider")
-        or target_provider_secret_values.get(SIMULATOR_TTS_PROVIDER_ALIAS)
+        or simulator_provider_secret_values.get(SIMULATOR_TTS_PROVIDER_ALIAS)
         or "deepgram"
     ).lower()
 
@@ -202,23 +219,31 @@ def _check_config(
     if "deepgram" in {stt_provider, tts_provider}:
         required.append(DEEPGRAM_API_KEY_ALIAS)
     missing_aliases = [
-        alias for alias in required if not target_provider_secret_values.get(alias)
+        alias
+        for alias in required
+        if not (
+            target_provider_secret_values.get(alias)
+            if alias in {LIVEKIT_API_KEY_ALIAS, LIVEKIT_API_SECRET_ALIAS}
+            else simulator_provider_secret_values.get(alias)
+        )
     ]
 
     if llm_provider == "google":
         has_api_key = bool(
-            target_provider_secret_values.get(GEMINI_API_KEY_ALIAS)
-            or target_provider_secret_values.get(GOOGLE_API_KEY_ALIAS)
+            simulator_provider_secret_values.get(GEMINI_API_KEY_ALIAS)
+            or simulator_provider_secret_values.get(GOOGLE_API_KEY_ALIAS)
         )
         has_vertex_adc = bool(
-            target_provider_secret_values.get(GOOGLE_APPLICATION_CREDENTIALS_JSON_ALIAS)
-            and target_provider_secret_values.get(GOOGLE_CLOUD_PROJECT_ALIAS)
+            simulator_provider_secret_values.get(
+                GOOGLE_APPLICATION_CREDENTIALS_JSON_ALIAS
+            )
+            and simulator_provider_secret_values.get(GOOGLE_CLOUD_PROJECT_ALIAS)
         )
         if not has_api_key and not has_vertex_adc:
             missing_aliases.append(
                 f"{GEMINI_API_KEY_ALIAS}_or_{GOOGLE_API_KEY_ALIAS}_or_VERTEX_ADC"
             )
-    elif llm_provider == "openai" and not target_provider_secret_values.get(
+    elif llm_provider == "openai" and not simulator_provider_secret_values.get(
         OPENAI_API_KEY_ALIAS
     ):
         missing_aliases.append(OPENAI_API_KEY_ALIAS)
@@ -231,6 +256,14 @@ def _check_config(
     if not missing_aliases and not missing_config_keys:
         return None
     return _MissingVoiceConfig(tuple(missing_aliases), tuple(missing_config_keys))
+
+
+def _canonical_simulator_secrets(values: Mapping[str, str]) -> dict[str, str]:
+    """Translate platform-only aliases into the names expected by simulator plugins."""
+    return {
+        _SIMULATOR_PLATFORM_ALIAS_MAP.get(alias, alias): value
+        for alias, value in values.items()
+    }
 
 
 def _dispatch_agent_name(runtime: EnvironmentRuntime) -> str | None:
@@ -596,6 +629,34 @@ class CallRunnerImpl:
         self._adapter = adapter
         self._context = context
         self._place_call = place_call or _default_place_call
+        simulator_secret_values = _canonical_simulator_secrets(
+            context.simulator_provider_secret_values
+        )
+        # Local SDK runs remain BYOK and historically carry simulator keys in the one local
+        # target map. Hosted runs deliberately do not fall back: their simulator credentials must
+        # come from platform configuration and must not be confused with customer-agent keys.
+        if context.job.execution is ExecutionMode.LOCAL:
+            for alias in (
+                DEEPGRAM_API_KEY_ALIAS,
+                CARTESIA_API_KEY_ALIAS,
+                GEMINI_API_KEY_ALIAS,
+                GOOGLE_API_KEY_ALIAS,
+                GOOGLE_APPLICATION_CREDENTIALS_JSON_ALIAS,
+                GOOGLE_CLOUD_PROJECT_ALIAS,
+                GOOGLE_CLOUD_LOCATION_ALIAS,
+                GOOGLE_GENAI_USE_VERTEXAI_ALIAS,
+                OPENAI_API_KEY_ALIAS,
+                SIMULATOR_LLM_PROVIDER_ALIAS,
+                SIMULATOR_LLM_MODEL_ALIAS,
+                SIMULATOR_STT_PROVIDER_ALIAS,
+                SIMULATOR_STT_MODEL_ALIAS,
+                SIMULATOR_TTS_PROVIDER_ALIAS,
+                SIMULATOR_TTS_MODEL_ALIAS,
+            ):
+                if alias not in simulator_secret_values:
+                    value = context.target_provider_secret_values.get(alias)
+                    if value:
+                        simulator_secret_values[alias] = value
         # WHY: the underlying LiveKit engine reads these directly via `os.environ.get(...)` deep
         # inside `engines/livekit.py` / `livekit_models.py` -- they are NOT `SimulationSpec`
         # fields, so there is no other way to hand them over. Exported ONCE here, at construction,
@@ -608,6 +669,11 @@ class CallRunnerImpl:
             LIVEKIT_API_KEY_ALIAS,
             LIVEKIT_API_SECRET_ALIAS,
             LIVEKIT_URL_ALIAS,
+        ):
+            value = context.target_provider_secret_values.get(alias)
+            if value:
+                target_environ[alias] = value
+        for alias in (
             DEEPGRAM_API_KEY_ALIAS,
             CARTESIA_API_KEY_ALIAS,
             GEMINI_API_KEY_ALIAS,
@@ -624,12 +690,12 @@ class CallRunnerImpl:
             SIMULATOR_TTS_PROVIDER_ALIAS,
             SIMULATOR_TTS_MODEL_ALIAS,
         ):
-            value = context.target_provider_secret_values.get(alias)
+            value = simulator_secret_values.get(alias)
             if value:
                 target_environ[alias] = value
         self._environ = target_environ
         self._adc_path = _materialize_vertex_adc(
-            context.target_provider_secret_values,
+            simulator_secret_values,
             context.work_directory,
             target_environ,
         )
@@ -640,7 +706,9 @@ class CallRunnerImpl:
             or ""
         )
         self._missing_config = _check_config(
-            context.job, context.target_provider_secret_values
+            context.job,
+            context.target_provider_secret_values,
+            simulator_secret_values,
         )
         self._scenario_attempt_counts: dict[str, int] = {}
 

--- a/src/fi/alk/harness/hosted_authoring_entrypoint.py
+++ b/src/fi/alk/harness/hosted_authoring_entrypoint.py
@@ -18,9 +18,14 @@ _SECRETS_PATH = Path("/run/futureagi/secrets.json")
 _ADC_PATH = Path("/work/.authoring-credentials/google.json")
 _PASSTHROUGH = {
     "ANTHROPIC_API_KEY",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "ANTHROPIC_VERTEX_REGION",
+    "CLOUD_ML_REGION",
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
+    "GOOGLE_CLOUD_LOCATION",
     "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_GENAI_USE_VERTEXAI",
     "OPENAI_API_KEY",
 }
 
@@ -36,6 +41,16 @@ def _load_values(path: Path) -> dict[str, str]:
     }
 
 
+def _platform_simulator_values(values: dict[str, str]) -> dict[str, str]:
+    """Canonicalize only platform-owned aliases; never use customer target values."""
+    prefix = "SIMULATOR_"
+    return {
+        name.removeprefix(prefix): value
+        for name, value in values.items()
+        if name.startswith(prefix)
+    }
+
+
 def _configure_generation_environment(values: dict[str, str]) -> None:
     for name in _PASSTHROUGH:
         if values.get(name):
@@ -45,9 +60,13 @@ def _configure_generation_environment(values: dict[str, str]) -> None:
     if adc_json:
         parsed = json.loads(adc_json)
         if not isinstance(parsed, dict):
-            raise ValueError("GOOGLE_APPLICATION_CREDENTIALS_JSON must contain an object")
+            raise ValueError(
+                "GOOGLE_APPLICATION_CREDENTIALS_JSON must contain an object"
+            )
         _ADC_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _ADC_PATH.write_text(json.dumps(parsed, separators=(",", ":")), encoding="utf-8")
+        _ADC_PATH.write_text(
+            json.dumps(parsed, separators=(",", ":")), encoding="utf-8"
+        )
         _ADC_PATH.chmod(0o600)
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(_ADC_PATH)
 
@@ -68,7 +87,7 @@ def _configure_generation_environment(values: dict[str, str]) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    values = _load_values(_SECRETS_PATH)
+    values = _platform_simulator_values(_load_values(_SECRETS_PATH))
     _configure_generation_environment(values)
     try:
         return authoring_main(argv)

--- a/src/fi/alk/harness/hosted_entrypoint.py
+++ b/src/fi/alk/harness/hosted_entrypoint.py
@@ -165,12 +165,14 @@ def peek_secret_values(secrets_path: Path) -> tuple[str, ...]:
     return tuple(str(value) for value in raw.values() if value)
 
 
-def peek_target_provider_secret_values(
-    secrets_path: Path, secret_purposes: dict[str, str]
+def peek_secret_values_for_purpose(
+    secrets_path: Path,
+    secret_purposes: dict[str, str],
+    purpose: str,
 ) -> dict[str, str]:
     """The same non-destructive, no-unlink read as `peek_secret_values` (same file, same timing
     constraint -- called BEFORE `pool.start()`, which is what actually deletes the file), but
-    ALIAS-preserving and filtered to `purpose: target_provider` -- `peek_secret_values` throws the
+    ALIAS-preserving and filtered to one explicit purpose -- `peek_secret_values` throws the
     alias away, which is fine for outbound redaction (it only needs the raw values) but useless for
     the real `CallRunner`, which needs to pick e.g. `LIVEKIT_API_KEY` out of the map by name. Never
     fatal: a missing/malformed file just means no target-provider secrets are available yet,
@@ -185,8 +187,24 @@ def peek_target_provider_secret_values(
     return {
         str(alias): str(value)
         for alias, value in raw.items()
-        if secret_purposes.get(str(alias)) == "target_provider"
+        if secret_purposes.get(str(alias)) == purpose
     }
+
+
+def peek_target_provider_secret_values(
+    secrets_path: Path, secret_purposes: dict[str, str]
+) -> dict[str, str]:
+    return peek_secret_values_for_purpose(
+        secrets_path, secret_purposes, "target_provider"
+    )
+
+
+def peek_simulator_provider_secret_values(
+    secrets_path: Path, secret_purposes: dict[str, str]
+) -> dict[str, str]:
+    return peek_secret_values_for_purpose(
+        secrets_path, secret_purposes, "simulator_provider"
+    )
 
 
 # =================================================================================================
@@ -235,6 +253,7 @@ _SECTION_2E_CODES = frozenset(
         "secret_in_bundle",
         "secret_unclaimed",
         "secret_missing",
+        "secret_purpose_forbidden",
         "build_requires_root",
         "user_assignment_invalid",
         "configuration_name_duplicate",
@@ -505,9 +524,7 @@ def _default_build_call_runner(
     the contract itself calls it "a follow-up, not shipped with this text")."""
     connector = context.job.agent.connector.lower()
     modality = _bundle_contract_modality(context.bundle_dir)
-    if connector == _LIVEKIT_CONNECTOR or (
-        connector == "auto" and modality == "voice"
-    ):
+    if connector == _LIVEKIT_CONNECTOR or (connector == "auto" and modality == "voice"):
         return CallRunnerImpl(adapter, context)
     # Repository-hosted text targets advertise their concrete HTTP interface in the frozen
     # contract adopted into Bundle V2. Connector-only Vapi/Retell remains on the existing
@@ -1216,15 +1233,18 @@ class OutboundAdapter:
             if build_path.is_file()
             else b'{"status":"build metadata unavailable"}\n'
         )
-        result = json.dumps(
-            {
-                "stage": stage.value,
-                "failure": failure,
-                "scenario_counts": self.scenario_counts,
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode() + b"\n"
+        result = (
+            json.dumps(
+                {
+                    "stage": stage.value,
+                    "failure": failure,
+                    "scenario_counts": self.scenario_counts,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+            + b"\n"
+        )
         log = (
             f"hosted harness terminal stage={stage.value}; "
             f"scenario_counts={json.dumps(self.scenario_counts, sort_keys=True)}\n"
@@ -1475,6 +1495,11 @@ class HostedEntrypointDeps:
         self, secret_purposes: dict[str, str]
     ) -> dict[str, str]:
         return peek_target_provider_secret_values(self.secrets_path, secret_purposes)
+
+    def peek_simulator_provider_secret_values(
+        self, secret_purposes: dict[str, str]
+    ) -> dict[str, str]:
+        return peek_simulator_provider_secret_values(self.secrets_path, secret_purposes)
 
 
 # =================================================================================================
@@ -1775,6 +1800,9 @@ async def run_job(
         target_provider_secret_values = deps.peek_target_provider_secret_values(
             secret_purposes
         )
+        simulator_provider_secret_values = deps.peek_simulator_provider_secret_values(
+            secret_purposes
+        )
         adapter.configure_artifacts(
             job.artifacts
         )  # level table + budget, now that job.json is known.
@@ -2034,6 +2062,7 @@ async def run_job(
             work_directory=work_directory,
             evidence_seam=manifest.runtime.evidence_seam,
             target_provider_secret_values=target_provider_secret_values,
+            simulator_provider_secret_values=simulator_provider_secret_values,
             attempt_number=capabilities.attempt_number,
             source_directory=source,
         )

--- a/src/fi/alk/harness/job.py
+++ b/src/fi/alk/harness/job.py
@@ -180,9 +180,17 @@ class HarnessJob(BaseModel):
             if self.artifacts.level is ArtifactLevel.LOCAL_ONLY:
                 raise ValueError("local_only_not_hosted")
             for alias, reference in self.agent.secret_refs.items():
-                if reference.manager != "platform-vault":
+                expected_manager = (
+                    "platform-config"
+                    if reference.purpose == "simulator_provider"
+                    else "platform-vault"
+                )
+                if reference.manager != expected_manager:
                     raise ValueError(f"hosted_secret_manager_unsupported: {alias}")
-                if reference.purpose != "target_provider":
+                if reference.purpose not in {
+                    "target_provider",
+                    "simulator_provider",
+                }:
                     raise ValueError(f"hosted_secret_purpose_invalid: {alias}")
             if self.security.allow_privileged:
                 raise ValueError("hosted_privileged_execution_forbidden")

--- a/src/fi/alk/harness/process_preflight.py
+++ b/src/fi/alk/harness/process_preflight.py
@@ -466,6 +466,19 @@ def _verify_secret_purposes(
 ) -> None:
     """§2b: both directions, scoped to `target_provider` only — `source_checkout` and any other
     gateway-only purpose never crosses into the guest (§0 step 3) and has nothing to claim here."""
+    simulator_claimants = [
+        process.name
+        for process in manifest.processes
+        if isinstance(process, SourceProcess)
+        and SecretPurpose.SIMULATOR_PROVIDER in process.secret_purposes
+    ]
+    if simulator_claimants:
+        raise PreflightError(
+            "secret_purpose_forbidden",
+            "customer processes cannot claim simulator_provider credentials: "
+            + ", ".join(sorted(simulator_claimants)),
+        )
+
     ref_has_target_provider = any(
         purpose == SecretPurpose.TARGET_PROVIDER.value
         for purpose in secret_refs.values()

--- a/src/fi/alk/harness/process_runtime.py
+++ b/src/fi/alk/harness/process_runtime.py
@@ -457,16 +457,19 @@ def select_process_secrets(
     preflight_bundle`'s own `secret_refs` argument uses, so a caller that already ran preflight
     has this for free.
 
-    `SecretPurpose.SOURCE_CHECKOUT` is excluded unconditionally (F13, p5-round1-review): §1 states
-    it is "gateway-only; never uploaded to the guest," and preflight does not forbid a process
-    from legally *claiming* it (§2b's `secret_unclaimed`/`secret_missing` pair is scoped to
-    `target_provider` only) — the guest should not depend on the gateway alone never putting one
-    in `secrets.json` to keep that promise.
+    `SecretPurpose.SOURCE_CHECKOUT` and `SecretPurpose.SIMULATOR_PROVIDER` are excluded
+    unconditionally. Checkout credentials are gateway-only. Simulator credentials belong to the
+    harness control/caller and must never enter a customer-authored process environment, even if
+    an untrusted or generated bundle attempts to claim that purpose.
     """
     claimed = {
         purpose.value
         for purpose in process.secret_purposes
-        if purpose is not SecretPurpose.SOURCE_CHECKOUT
+        if purpose
+        not in {
+            SecretPurpose.SOURCE_CHECKOUT,
+            SecretPurpose.SIMULATOR_PROVIDER,
+        }
     }
     return {
         alias: value

--- a/tests/harness/test_call_runner.py
+++ b/tests/harness/test_call_runner.py
@@ -65,17 +65,28 @@ _ALL_CONFIG = {cr.LIVEKIT_URL_CONFIG_KEY: "wss://example.livekit.cloud"}
 
 
 def _job(
-    *, connector: str = "livekit", config: dict[str, Any] | None = None
+    *,
+    connector: str = "livekit",
+    config: dict[str, Any] | None = None,
+    execution: ExecutionMode = ExecutionMode.HOSTED,
 ) -> HarnessJob:
     return HarnessJob(
         job_id="job-abcdef12-xyz",
         run_id="run-1",
-        execution=ExecutionMode.HOSTED,
-        source=RepositorySource(
-            kind=SourceKind.GITHUB,
-            repository="org/repo",
-            visibility=SourceVisibility.PUBLIC,
-            commit_sha="a" * 40,
+        execution=execution,
+        source=(
+            RepositorySource(
+                kind=SourceKind.LOCAL_REPOSITORY,
+                local_path="/tmp/agent",
+                visibility=SourceVisibility.PRIVATE,
+            )
+            if execution is ExecutionMode.LOCAL
+            else RepositorySource(
+                kind=SourceKind.GITHUB,
+                repository="org/repo",
+                visibility=SourceVisibility.PUBLIC,
+                commit_sha="a" * 40,
+            )
         ),
         agent=AgentConnection(connector=connector, config=config or {}),
         scenario_count=1,
@@ -160,11 +171,15 @@ def _context(
     connector: str = "livekit",
     config: dict[str, Any] | None = None,
     secrets: dict[str, str] | None = None,
+    simulator_secrets: dict[str, str] | None = None,
+    execution: ExecutionMode = ExecutionMode.HOSTED,
     evidence_seam: EvidenceSeam | None = EvidenceSeam.HTTP_TOOL,
     attempt_number: int = 1,
 ) -> tuple[HarnessJob, cr.CallRunnerContext]:
     job = _job(
-        connector=connector, config=config if config is not None else dict(_ALL_CONFIG)
+        connector=connector,
+        config=config if config is not None else dict(_ALL_CONFIG),
+        execution=execution,
     )
     bundle_dir = tmp_path / "bundle"
     bundle_dir.mkdir(parents=True, exist_ok=True)
@@ -177,6 +192,14 @@ def _context(
         if secrets is not None
         else dict(_ALL_SECRETS),
         attempt_number=attempt_number,
+        simulator_provider_secret_values=(
+            simulator_secrets
+            if simulator_secrets is not None
+            else {
+                "SIMULATOR_DEEPGRAM_API_KEY": _ALL_SECRETS[DEEPGRAM_API_KEY],
+                "SIMULATOR_GEMINI_API_KEY": _ALL_SECRETS[GEMINI_API_KEY],
+            }
+        ),
     )
     return job, context
 
@@ -361,9 +384,10 @@ def test_missing_target_provider_secrets_aborts_pre_dial_without_calling_place_c
 
 
 def test_missing_llm_credential_names_the_either_or_pair(tmp_path: Path) -> None:
-    secrets = dict(_ALL_SECRETS)
-    del secrets[GEMINI_API_KEY]
-    _job_obj, context = _context(tmp_path=tmp_path, secrets=secrets)
+    _job_obj, context = _context(
+        tmp_path=tmp_path,
+        simulator_secrets={"SIMULATOR_DEEPGRAM_API_KEY": "dg-key"},
+    )
     runner = cr.CallRunnerImpl(FakeAdapter(), context)
     exc = _run_expect_abort(
         runner,
@@ -376,10 +400,13 @@ def test_missing_llm_credential_names_the_either_or_pair(tmp_path: Path) -> None
 def test_google_api_key_alone_satisfies_the_llm_credential_check(
     tmp_path: Path,
 ) -> None:
-    secrets = dict(_ALL_SECRETS)
-    del secrets[GEMINI_API_KEY]
-    secrets["GOOGLE_API_KEY"] = "g-key"
-    _job_obj, context = _context(tmp_path=tmp_path, secrets=secrets)
+    _job_obj, context = _context(
+        tmp_path=tmp_path,
+        simulator_secrets={
+            "SIMULATOR_DEEPGRAM_API_KEY": "dg-key",
+            "SIMULATOR_GOOGLE_API_KEY": "g-key",
+        },
+    )
     runner = cr.CallRunnerImpl(FakeAdapter(), context)
     assert runner._missing_config is None
 
@@ -1097,3 +1124,54 @@ def test_construction_never_exports_secrets_outside_the_target_provider_map(
     _job_obj, context = _context(tmp_path=tmp_path, secrets=secrets)
     cr.CallRunnerImpl(FakeAdapter(), context, environ=fake_environ)
     assert "UNRELATED_ALIAS" not in fake_environ
+
+
+def test_construction_uses_platform_simulator_key_without_exposing_agent_model_key(
+    tmp_path: Path,
+) -> None:
+    fake_environ: dict[str, str] = {}
+    target = {
+        LIVEKIT_API_KEY: "lk-key",
+        LIVEKIT_API_SECRET: "lk-secret",
+        "ANTHROPIC_API_KEY": "customer-agent-key",
+    }
+    simulator = {
+        "SIMULATOR_DEEPGRAM_API_KEY": "platform-deepgram-key",
+        "SIMULATOR_GEMINI_API_KEY": "platform-gemini-key",
+    }
+    _job_obj, context = _context(
+        tmp_path=tmp_path,
+        secrets=target,
+        simulator_secrets=simulator,
+    )
+    cr.CallRunnerImpl(FakeAdapter(), context, environ=fake_environ)
+    assert fake_environ[DEEPGRAM_API_KEY] == "platform-deepgram-key"
+    assert fake_environ[GEMINI_API_KEY] == "platform-gemini-key"
+    assert "ANTHROPIC_API_KEY" not in fake_environ
+
+
+def test_hosted_run_never_falls_back_to_customer_simulator_keys(tmp_path: Path) -> None:
+    fake_environ: dict[str, str] = {}
+    target = dict(_ALL_SECRETS)
+    _job_obj, context = _context(
+        tmp_path=tmp_path,
+        secrets=target,
+        simulator_secrets={},
+    )
+    runner = cr.CallRunnerImpl(FakeAdapter(), context, environ=fake_environ)
+    assert DEEPGRAM_API_KEY not in fake_environ
+    assert GEMINI_API_KEY not in fake_environ
+    assert runner._missing_config is not None
+
+
+def test_local_sdk_remains_byok_for_simulator_credentials(tmp_path: Path) -> None:
+    fake_environ: dict[str, str] = {}
+    _job_obj, context = _context(
+        tmp_path=tmp_path,
+        execution=ExecutionMode.LOCAL,
+        simulator_secrets={},
+    )
+    runner = cr.CallRunnerImpl(FakeAdapter(), context, environ=fake_environ)
+    assert fake_environ[DEEPGRAM_API_KEY] == "dg-key"
+    assert fake_environ[GEMINI_API_KEY] == "gm-key"
+    assert runner._missing_config is None

--- a/tests/harness/test_hosted_authoring_entrypoint.py
+++ b/tests/harness/test_hosted_authoring_entrypoint.py
@@ -5,6 +5,23 @@ import json
 from fi.alk.harness import hosted_authoring_entrypoint as entrypoint
 
 
+def test_platform_simulator_values_ignore_customer_target_credentials() -> None:
+    values = entrypoint._platform_simulator_values(
+        {
+            "ANTHROPIC_API_KEY": "customer-agent-key",
+            "GOOGLE_APPLICATION_CREDENTIALS_JSON": "customer-agent-adc",
+            "SIMULATOR_GOOGLE_APPLICATION_CREDENTIALS_JSON": "platform-adc",
+            "SIMULATOR_GOOGLE_CLOUD_PROJECT": "platform-project",
+        }
+    )
+
+    assert values == {
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON": "platform-adc",
+        "GOOGLE_CLOUD_PROJECT": "platform-project",
+    }
+    assert "ANTHROPIC_API_KEY" not in values
+
+
 def test_vertex_generation_region_is_not_copied_from_google_location(
     tmp_path, monkeypatch
 ) -> None:
@@ -27,7 +44,9 @@ def test_explicit_claude_vertex_region_wins(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
     entrypoint._configure_generation_environment(
         {
-            "GOOGLE_APPLICATION_CREDENTIALS_JSON": json.dumps({"type": "service_account"}),
+            "GOOGLE_APPLICATION_CREDENTIALS_JSON": json.dumps(
+                {"type": "service_account"}
+            ),
             "GOOGLE_CLOUD_PROJECT": "p",
             "ANTHROPIC_VERTEX_REGION": "europe-west1",
         }

--- a/tests/harness/test_hosted_entrypoint.py
+++ b/tests/harness/test_hosted_entrypoint.py
@@ -207,6 +207,44 @@ def _write_job(path: Path, job: HarnessJob) -> None:
     path.write_text(job.model_dump_json(), encoding="utf-8")
 
 
+def test_hosted_job_accepts_internal_platform_simulator_ref() -> None:
+    job = _job()
+    refs = dict(job.agent.secret_refs)
+    refs["SIMULATOR_DEEPGRAM_API_KEY"] = SecretRef(
+        manager="platform-config",
+        key="SIMULATOR_DEEPGRAM_API_KEY",
+        purpose="simulator_provider",
+    )
+
+    validated = HarnessJob.model_validate(
+        job.model_dump() | {"agent": job.agent.model_dump() | {"secret_refs": refs}}
+    )
+
+    assert (
+        validated.agent.secret_refs["SIMULATOR_DEEPGRAM_API_KEY"].purpose
+        == "simulator_provider"
+    )
+
+
+def test_hosted_job_rejects_simulator_ref_from_customer_vault() -> None:
+    job = _job()
+    refs = dict(job.agent.secret_refs)
+    refs["SIMULATOR_DEEPGRAM_API_KEY"] = SecretRef(
+        manager="platform-vault",
+        key="customer-selected",
+        purpose="simulator_provider",
+    )
+
+    try:
+        HarnessJob.model_validate(
+            job.model_dump() | {"agent": job.agent.model_dump() | {"secret_refs": refs}}
+        )
+    except ValueError as exc:
+        assert "hosted_secret_manager_unsupported" in str(exc)
+    else:
+        raise AssertionError("customer-vault simulator ref must be rejected")
+
+
 # =================================================================================================
 # Capabilities fixture.
 # =================================================================================================
@@ -893,6 +931,30 @@ def test_peek_target_provider_secret_values_drops_an_alias_with_no_purpose_entry
     assert he.peek_target_provider_secret_values(path, {}) == {}
 
 
+def test_peek_simulator_provider_secret_values_isolated_from_target_provider() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="simulator-secrets-"))
+    path = tmp / "secrets.json"
+    path.write_text(
+        json.dumps(
+            {
+                "AGENT_ANTHROPIC_API_KEY": "customer-key",
+                "SIMULATOR_DEEPGRAM_API_KEY": "platform-key",
+            }
+        ),
+        encoding="utf-8",
+    )
+    purposes = {
+        "AGENT_ANTHROPIC_API_KEY": "target_provider",
+        "SIMULATOR_DEEPGRAM_API_KEY": "simulator_provider",
+    }
+    assert he.peek_simulator_provider_secret_values(path, purposes) == {
+        "SIMULATOR_DEEPGRAM_API_KEY": "platform-key"
+    }
+    assert he.peek_target_provider_secret_values(path, purposes) == {
+        "AGENT_ANTHROPIC_API_KEY": "customer-key"
+    }
+
+
 # =================================================================================================
 # CallRunner wiring (p14): the extended build_call_runner(adapter, context) seam, and the
 # NotWired-stays-the-fallback / real-CallRunnerImpl split on `agent.connector`.
@@ -922,7 +984,9 @@ def test_default_build_call_runner_returns_notwired_for_a_non_livekit_connector(
     assert isinstance(runner, he.NotWiredCallRunner)
 
 
-def test_default_build_call_runner_returns_notwired_for_retell_and_unresolved_auto() -> None:
+def test_default_build_call_runner_returns_notwired_for_retell_and_unresolved_auto() -> (
+    None
+):
     for connector in ("retell", "auto"):
         runner = he._default_build_call_runner(
             mock.Mock(), _call_runner_context(job=_job(connector=connector))

--- a/tests/harness/test_process_preflight.py
+++ b/tests/harness/test_process_preflight.py
@@ -44,7 +44,11 @@ def _base_manifest_body() -> dict[str, Any]:
     return {
         "schema_version": BUNDLE_V2_SCHEMA_VERSION,
         "name": "demo",
-        "runtime": {"kind": "process", "control_service": "agent", "evidence_seam": "http_tool"},
+        "runtime": {
+            "kind": "process",
+            "control_service": "agent",
+            "evidence_seam": "http_tool",
+        },
         "processes": [
             {
                 "name": "postgres",
@@ -78,7 +82,9 @@ def _base_manifest_body() -> dict[str, Any]:
         },
         "readiness": [],
         "provenance": {
-            "source_kind": "repository", "repository": "org/repo", "source_digest": "c" * 64
+            "source_kind": "repository",
+            "repository": "org/repo",
+            "source_digest": "c" * 64,
         },
         "metadata": {},
     }
@@ -110,13 +116,21 @@ def _build_bundle(
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
         files.append(
-            {"path": relative, "sha256": hashlib.sha256(content).hexdigest(), "size": len(content)}
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+            }
         )
     body["files"] = files
 
     if include_seed:
         digest = compute_inputs_digest(
-            root, ["db/schema.sql"], ["db/seed.sql"], engine=ManagedEngine.POSTGRES, version="16"
+            root,
+            ["db/schema.sql"],
+            ["db/seed.sql"],
+            engine=ManagedEngine.POSTGRES,
+            version="16",
         )
         body["seed"] = {
             "stores": [
@@ -124,8 +138,14 @@ def _build_bundle(
                     "capability": "database",
                     "migrations": ["db/schema.sql"],
                     "seed_files": ["db/seed.sql"],
-                    "baseline": {"strategy": "template_database", "inputs_digest": digest},
-                    "sentinel": {"query": "SELECT count(*) FROM riders", "expected": "1"},
+                    "baseline": {
+                        "strategy": "template_database",
+                        "inputs_digest": digest,
+                    },
+                    "sentinel": {
+                        "query": "SELECT count(*) FROM riders",
+                        "expected": "1",
+                    },
                 }
             ]
         }
@@ -195,7 +215,9 @@ def test_a_symlink_anywhere_under_the_bundle_is_rejected(tmp_path: Path) -> None
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_the_root_manifest_json_itself_being_a_symlink_is_rejected(tmp_path: Path) -> None:
+def test_the_root_manifest_json_itself_being_a_symlink_is_rejected(
+    tmp_path: Path,
+) -> None:
     """N3 (p4-round2-review): the root `manifest.json` is exempt from the listing check (a
     manifest cannot list itself), but that exemption must not extend to its symlink status — a
     symlinked root manifest was previously read straight through by `_verify_digest` and
@@ -209,7 +231,9 @@ def test_the_root_manifest_json_itself_being_a_symlink_is_rejected(tmp_path: Pat
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_a_file_present_on_disk_but_not_listed_in_files_is_rejected(tmp_path: Path) -> None:
+def test_a_file_present_on_disk_but_not_listed_in_files_is_rejected(
+    tmp_path: Path,
+) -> None:
     """F1 (p4-round1-review): a bundle directory containing a file the producer never hashed into
     `files[]` was invisible to both the digest check and the secret scan — this is the case that
     previously slipped a `.env` through undetected. `extra_files` (used by the item-3 tests below)
@@ -228,9 +252,12 @@ def test_a_dotenv_file_in_the_bundle_is_rejected(tmp_path: Path) -> None:
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_high_entropy_secret_content_in_a_bundle_file_is_rejected(tmp_path: Path) -> None:
+def test_high_entropy_secret_content_in_a_bundle_file_is_rejected(
+    tmp_path: Path,
+) -> None:
     manifest = _build_bundle(
-        tmp_path, extra_files={"db/notes.sql": b"-----BEGIN RSA PRIVATE KEY-----\nabc\n"}
+        tmp_path,
+        extra_files={"db/notes.sql": b"-----BEGIN RSA PRIVATE KEY-----\nabc\n"},
     )
     with pytest.raises(PreflightError, match="secret_in_bundle"):
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
@@ -239,7 +266,9 @@ def test_high_entropy_secret_content_in_a_bundle_file_is_rejected(tmp_path: Path
 # --- item 4: unknown-field translation ------------------------------------------------------------
 
 
-def test_an_unknown_field_added_to_the_manifest_on_disk_is_rejected(tmp_path: Path) -> None:
+def test_an_unknown_field_added_to_the_manifest_on_disk_is_rejected(
+    tmp_path: Path,
+) -> None:
     """The `manifest` argument is already-parsed and therefore already clean; this proves the
     translation fires against the bytes on disk, which is what a drifted or hand-edited
     `manifest.json` would look like to a fresh `EnvironmentBundleV2.model_validate` call."""
@@ -273,7 +302,9 @@ def test_an_unreadable_manifest_json_on_disk_is_rejected(tmp_path: Path) -> None
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_a_non_extra_forbidden_model_rejection_surfaces_its_own_code(tmp_path: Path) -> None:
+def test_a_non_extra_forbidden_model_rejection_surfaces_its_own_code(
+    tmp_path: Path,
+) -> None:
     """F13/F18 (p4-round1-review): `_translate_validation_error`'s fallback path was untested. A
     malformed on-disk `digest` (item 1 never reads it — only the `manifest` argument's own valid
     digest and file hashes, which are untouched here) reaches item 4's re-validation and raises
@@ -313,7 +344,9 @@ def test_kind_compose_is_rejected(tmp_path: Path) -> None:
 # seed_missing, reserved names, build_requires_root, seed files on disk+listed ---------------------
 
 
-def test_a_placeholder_outside_the_closed_vocabulary_is_rejected(tmp_path: Path) -> None:
+def test_a_placeholder_outside_the_closed_vocabulary_is_rejected(
+    tmp_path: Path,
+) -> None:
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["environment"]["FOO"] = "{{NOT_A_REAL_TOKEN}}"
         return body
@@ -323,7 +356,9 @@ def test_a_placeholder_outside_the_closed_vocabulary_is_rejected(tmp_path: Path)
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_a_port_placeholder_naming_an_unknown_process_is_rejected(tmp_path: Path) -> None:
+def test_a_port_placeholder_naming_an_unknown_process_is_rejected(
+    tmp_path: Path,
+) -> None:
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["environment"]["PEER_PORT"] = "{{PORT_ghost-service}}"
         return body
@@ -340,6 +375,7 @@ def test_a_port_placeholder_with_an_empty_name_falls_through_to_unknown_placehol
     `PORT_`/`HOST_`, so `{{PORT_}}` does not match the named-placeholder pattern at all — it falls
     through to the configuration-name set, misses, and is rejected as `unknown_placeholder`. A
     plausible regression target if `(.+)` is ever relaxed to `(.*)`."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["environment"]["EMPTY"] = "{{PORT_}}"
         return body
@@ -357,6 +393,7 @@ def test_a_token_naming_a_capability_with_no_configuration_name_is_capability_un
     slug, the real problem is the capability's missing name, not an unrecognized token, so this is
     reported `capability_unresolved` naming the capability rather than the generic
     `unknown_placeholder`."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["capabilities"]["cache"] = {"protocol": "http", "service": "postgres"}
         body["processes"][1]["environment"]["FOO"] = "{{cache}}"
@@ -367,10 +404,13 @@ def test_a_token_naming_a_capability_with_no_configuration_name_is_capability_un
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_build_environment_rejects_any_placeholder_even_a_legal_one(tmp_path: Path) -> None:
+def test_build_environment_rejects_any_placeholder_even_a_legal_one(
+    tmp_path: Path,
+) -> None:
     """F6 (p4-round1-review): §2b's `build_environment` takes NO placeholders at all — this uses
     `{{WORLD_DIR}}`, a perfectly legal token in `environment`, specifically because that is the
     case a naive "scan against the same vocabulary" implementation would wave through."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["build_environment"] = {"TMPDIR": "{{WORLD_DIR}}"}
         return body
@@ -383,6 +423,7 @@ def test_build_environment_rejects_any_placeholder_even_a_legal_one(tmp_path: Pa
 def test_the_fixed_and_named_placeholders_are_accepted(tmp_path: Path) -> None:
     """`{{WORLD_INDEX}}`/`{{WORLD_DIR}}`/`{{DB_NAME}}` need no lookup; `{{PORT_<name>}}` and
     `{{HOST_<name>}}` need only a real process name — neither needs a capability."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["environment"]["SCRATCH"] = "{{WORLD_DIR}}"
         body["processes"][1]["environment"]["DB"] = "{{DB_NAME}}"
@@ -404,10 +445,13 @@ def test_a_build_command_requiring_root_is_rejected(tmp_path: Path) -> None:
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_a_build_command_with_sudo_anywhere_in_the_step_is_rejected(tmp_path: Path) -> None:
+def test_a_build_command_with_sudo_anywhere_in_the_step_is_rejected(
+    tmp_path: Path,
+) -> None:
     """F18 (p4-round1-review): only `apt-get` as argv[0] was exercised before — `"sudo" in step`
     is exact-token list membership, not a substring match, so `sudo` appearing anywhere in the
     argv list (not just as argv[0]) must trip it too."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["build_commands"] = [["scripts/setup.sh", "--with-sudo", "sudo"]]
         return body
@@ -427,7 +471,22 @@ def test_a_target_provider_ref_no_process_lists_is_rejected(tmp_path: Path) -> N
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_a_listed_secret_purpose_with_no_supplying_ref_is_rejected(tmp_path: Path) -> None:
+def test_customer_process_cannot_claim_simulator_provider_secrets(
+    tmp_path: Path,
+) -> None:
+    def mutate(body: dict[str, Any]) -> dict[str, Any]:
+        body["processes"][1]["secret_purposes"].append("simulator_provider")
+        return body
+
+    manifest = _build_bundle(tmp_path, body_overrides=mutate)
+    refs = {**TARGET_PROVIDER_REFS, "SIMULATOR_DEEPGRAM_API_KEY": "simulator_provider"}
+    with pytest.raises(PreflightError, match="secret_purpose_forbidden"):
+        preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=refs)
+
+
+def test_a_listed_secret_purpose_with_no_supplying_ref_is_rejected(
+    tmp_path: Path,
+) -> None:
     manifest = _build_bundle(tmp_path)
     with pytest.raises(PreflightError, match="secret_missing"):
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs={})
@@ -453,7 +512,10 @@ def test_an_unrecognized_secret_purpose_value_is_rejected(tmp_path: Path) -> Non
     manifest = _build_bundle(tmp_path)
     with pytest.raises(ValueError, match="not a SecretPurpose"):
         preflight_bundle(
-            tmp_path, manifest, parallelism=1, secret_refs={"LIVEKIT_API_KEY": "target-provider"}
+            tmp_path,
+            manifest,
+            parallelism=1,
+            secret_refs={"LIVEKIT_API_KEY": "target-provider"},
         )
 
 
@@ -489,9 +551,7 @@ def test_an_engine_version_outside_the_catalog_pin_is_rejected(tmp_path: Path) -
 
 
 @pytest.mark.parametrize("colliding_port", [14000, 14099, 15000, 15799])
-def test_a_fixed_port_colliding_with_a_port_formula_band_is_rejected(
-    tmp_path: Path, colliding_port: int
-) -> None:
+def test_a_fixed_port_colliding_with_a_port_formula_band_is_rejected(tmp_path: Path, colliding_port: int) -> None:
     """F11, p5-round1-review: `fixed_port` forces effective parallelism to 1, but the literal
     value was never checked against the provisioner's own port-formula bands — a bundle declaring
     `fixed_port: 14000` collides with a job-shared engine at ordinal 0, and the failure mode is an
@@ -532,9 +592,7 @@ def test_a_fixed_port_outside_both_bands_is_accepted(tmp_path: Path) -> None:
         return body
 
     manifest = _build_bundle(tmp_path, body_overrides=mutate)
-    assert preflight_bundle(
-        tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS
-    ) is None
+    assert preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS) is None
 
 
 def test_a_postgres_capability_with_no_store_entry_is_rejected(tmp_path: Path) -> None:
@@ -562,7 +620,11 @@ def _reseal_schema_sql(tmp_path: Path, content: bytes) -> EnvironmentBundleV2:
             record["sha256"] = hashlib.sha256(content).hexdigest()
             record["size"] = len(content)
     raw["seed"]["stores"][0]["baseline"]["inputs_digest"] = compute_inputs_digest(
-        tmp_path, ["db/schema.sql"], ["db/seed.sql"], engine=ManagedEngine.POSTGRES, version="16"
+        tmp_path,
+        ["db/schema.sql"],
+        ["db/seed.sql"],
+        engine=ManagedEngine.POSTGRES,
+        version="16",
     )
     raw["digest"] = "sha256:" + "0" * 64
     normalized = EnvironmentBundleV2.model_validate(raw)
@@ -571,14 +633,18 @@ def _reseal_schema_sql(tmp_path: Path, content: bytes) -> EnvironmentBundleV2:
     return EnvironmentBundleV2.model_validate(raw)
 
 
-def test_the_reserved_conformance_name_in_migration_content_is_rejected(tmp_path: Path) -> None:
+def test_the_reserved_conformance_name_in_migration_content_is_rejected(
+    tmp_path: Path,
+) -> None:
     _build_bundle(tmp_path)
     manifest = _reseal_schema_sql(tmp_path, b"CREATE TABLE _alk_conformance (id int);\n")
     with pytest.raises(PreflightError, match="reserved_name"):
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_the_reserved_conformance_name_is_matched_case_insensitively(tmp_path: Path) -> None:
+def test_the_reserved_conformance_name_is_matched_case_insensitively(
+    tmp_path: Path,
+) -> None:
     """F9 (p4-round1-review): postgres folds an unquoted identifier to lower case, so
     `CREATE TABLE _ALK_CONFORMANCE` creates the reserved table under its lower-case name — a
     case-sensitive scan would miss exactly the evasion this exists to catch."""
@@ -598,8 +664,7 @@ def test_a_similarly_named_table_and_a_comment_mentioning_the_reserved_name_are_
     _build_bundle(tmp_path)
     manifest = _reseal_schema_sql(
         tmp_path,
-        b"CREATE TABLE alk_conformance_backup (id int);\n"
-        b"-- never create _alk_conformance here\n",
+        b"CREATE TABLE alk_conformance_backup (id int);\n-- never create _alk_conformance here\n",
     )
     result = preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
     assert result is None
@@ -610,6 +675,7 @@ def test_a_migration_path_not_listed_in_files_is_rejected(tmp_path: Path) -> Non
     the same "on disk but not in files[]" condition — item 2's bundle-wide walk now runs first and
     always wins this exact scenario, which is why this asserts the earlier-numbered item's code
     rather than the one this test used to name before F1 closed item 2's gap."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["seed"]["stores"][0]["migrations"] = ["db/schema.sql", "db/extra.sql"]
         return body
@@ -621,7 +687,9 @@ def test_a_migration_path_not_listed_in_files_is_rejected(tmp_path: Path) -> Non
         preflight_bundle(tmp_path, manifest, parallelism=1, secret_refs=TARGET_PROVIDER_REFS)
 
 
-def test_a_seed_file_path_that_does_not_exist_on_disk_is_rejected(tmp_path: Path) -> None:
+def test_a_seed_file_path_that_does_not_exist_on_disk_is_rejected(
+    tmp_path: Path,
+) -> None:
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["seed"]["stores"][0]["seed_files"] = ["db/seed.sql", "db/ghost.sql"]
         return body
@@ -637,6 +705,7 @@ def test_a_recorded_inputs_digest_that_does_not_match_the_seed_files_is_rejected
     """F14 (p4-round1-review): §2c makes `inputs_digest` the baseline identity attempt-retry reuse
     trusts absolutely — nothing on either side of the seam validated it before. `engine`/`version`
     come from the store's capability's own backing `ManagedProcess` (postgres/16 here)."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["seed"]["stores"][0]["baseline"]["inputs_digest"] = "sha256:" + "f" * 64
         return body
@@ -649,10 +718,13 @@ def test_a_recorded_inputs_digest_that_does_not_match_the_seed_files_is_rejected
 # --- item 6: no_sql_store ------------------------------------------------------------------------
 
 
-def test_a_process_bundle_with_no_postgres_capability_is_rejected(tmp_path: Path) -> None:
+def test_a_process_bundle_with_no_postgres_capability_is_rejected(
+    tmp_path: Path,
+) -> None:
     """Keeps the `database` capability (so the `{{DATABASE_URL}}` placeholder in `agent`'s
     environment still resolves) and only changes its protocol away from postgres, isolating this
     from the placeholder-vocabulary check that would otherwise fire first."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["capabilities"]["database"]["protocol"] = "http"
         body["seed"] = None
@@ -692,7 +764,10 @@ def test_parallelism_outside_1_to_8_is_rejected(tmp_path: Path, parallelism: int
     manifest = _build_bundle(tmp_path)
     with pytest.raises(PreflightError, match="parallelism_out_of_range"):
         preflight_bundle(
-            tmp_path, manifest, parallelism=parallelism, secret_refs=TARGET_PROVIDER_REFS
+            tmp_path,
+            manifest,
+            parallelism=parallelism,
+            secret_refs=TARGET_PROVIDER_REFS,
         )
 
 
@@ -705,6 +780,7 @@ def test_a_secret_file_and_an_unknown_placeholder_together_report_the_earlier_nu
     tmp_path: Path,
 ) -> None:
     """Item 3 (secret scan) before item 5 (placeholder vocabulary)."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["environment"]["FOO"] = "{{NOT_A_REAL_TOKEN}}"
         return body
@@ -730,6 +806,7 @@ def test_a_placeholder_and_bad_parallelism_together_report_the_earlier_numbered_
     tmp_path: Path,
 ) -> None:
     """Item 5 (placeholder vocabulary) before item 7 (resource sanity)."""
+
     def mutate(body: dict[str, Any]) -> dict[str, Any]:
         body["processes"][1]["environment"]["FOO"] = "{{NOT_A_REAL_TOKEN}}"
         return body
@@ -899,31 +976,71 @@ def _raised_codes(source_text: str, callee_name: str, *, whole_first_argument: b
 # §2e's closed failure-code table (v1.9), transcribed verbatim — the single source of truth every
 # raised code is checked against. Split exactly as the contract text splits it, purely for
 # reviewability against the spec; the test below treats it as one flat set.
-_SECTION_2E_CONTRACT_RULE_CODES = frozenset({
-    "compose_not_hosted", "engine_unsupported", "no_sql_store", "seed_missing",
-    "seed_strategy_unsupported", "sentinel_shape_mismatch", "store_protocol_unsupported",
-    "capability_engine_mismatch", "store_service_not_managed", "reserved_name",
-    "unknown_placeholder", "unknown_field", "secret_in_bundle", "secret_unclaimed",
-    "secret_missing", "build_requires_root", "user_assignment_invalid",
-    "configuration_name_duplicate", "configuration_name_required",
-    "configuration_name_reserved", "sentinel_shape_invalid", "capability_unresolved",
-    "service_unresolved", "control_service_unresolved", "process_name_duplicate",
-    "inputs_digest_mismatch",
-    "fixed_port_reserved",  # §2e, v1.9.
-})
-_SECTION_2E_MECHANICAL_CODES = frozenset({
-    "bundle_schema_unsupported", "bundle_manifest_invalid", "bundle_manifest_drifted",
-    "bundle_digest_mismatch", "bundle_digest_invalid", "inputs_digest_invalid",
-    "file_sha256_invalid", "source_digest_invalid", "bundle_file_missing",
-    "bundle_file_changed", "bundle_file_unlisted", "bundle_symlink_forbidden",
-    "bundle_path_unsafe", "depends_on_unresolved", "depends_on_cycle", "seed_file_missing",
-    "seed_file_unlisted", "process_count_exceeded", "parallelism_out_of_range",
-    "evidence_seam_required", "processes_required", "processes_and_seed_forbidden",
-    "document_only_for_compose", "compose_runtime_requires_document",
-    "build_command_step_empty", "started_check_requires_exactly_one_of_port_or_log_marker",
-    "resolved_secret_forbidden", "capability_slug_invalid",
-    "process_name_invalid",  # §0/§2b v1.8: the process-`name` pattern rule.
-})
+_SECTION_2E_CONTRACT_RULE_CODES = frozenset(
+    {
+        "compose_not_hosted",
+        "engine_unsupported",
+        "no_sql_store",
+        "seed_missing",
+        "seed_strategy_unsupported",
+        "sentinel_shape_mismatch",
+        "store_protocol_unsupported",
+        "capability_engine_mismatch",
+        "store_service_not_managed",
+        "reserved_name",
+        "unknown_placeholder",
+        "unknown_field",
+        "secret_in_bundle",
+        "secret_unclaimed",
+        "secret_missing",
+        "secret_purpose_forbidden",
+        "build_requires_root",
+        "user_assignment_invalid",
+        "configuration_name_duplicate",
+        "configuration_name_required",
+        "configuration_name_reserved",
+        "sentinel_shape_invalid",
+        "capability_unresolved",
+        "service_unresolved",
+        "control_service_unresolved",
+        "process_name_duplicate",
+        "inputs_digest_mismatch",
+        "fixed_port_reserved",  # §2e, v1.9.
+    }
+)
+_SECTION_2E_MECHANICAL_CODES = frozenset(
+    {
+        "bundle_schema_unsupported",
+        "bundle_manifest_invalid",
+        "bundle_manifest_drifted",
+        "bundle_digest_mismatch",
+        "bundle_digest_invalid",
+        "inputs_digest_invalid",
+        "file_sha256_invalid",
+        "source_digest_invalid",
+        "bundle_file_missing",
+        "bundle_file_changed",
+        "bundle_file_unlisted",
+        "bundle_symlink_forbidden",
+        "bundle_path_unsafe",
+        "depends_on_unresolved",
+        "depends_on_cycle",
+        "seed_file_missing",
+        "seed_file_unlisted",
+        "process_count_exceeded",
+        "parallelism_out_of_range",
+        "evidence_seam_required",
+        "processes_required",
+        "processes_and_seed_forbidden",
+        "document_only_for_compose",
+        "compose_runtime_requires_document",
+        "build_command_step_empty",
+        "started_check_requires_exactly_one_of_port_or_log_marker",
+        "resolved_secret_forbidden",
+        "capability_slug_invalid",
+        "process_name_invalid",  # §0/§2b v1.8: the process-`name` pattern rule.
+    }
+)
 _SECTION_2E_CODES = _SECTION_2E_CONTRACT_RULE_CODES | _SECTION_2E_MECHANICAL_CODES
 
 
@@ -931,18 +1048,23 @@ def test_every_code_these_modules_can_raise_is_in_the_closed_section_2e_table() 
     raised: set[str] = set()
     raised |= _raised_codes(
         Path(inspect.getfile(process_preflight_module)).read_text(encoding="utf-8"),
-        "PreflightError", whole_first_argument=True,
+        "PreflightError",
+        whole_first_argument=True,
     )
     raised |= _raised_codes(
         Path(inspect.getfile(bundle_v2_module)).read_text(encoding="utf-8"),
-        "ValueError", whole_first_argument=False,
+        "ValueError",
+        whole_first_argument=False,
     )
     raised |= _raised_codes(
-        inspect.getsource(bundle_module._safe_relative), "ValueError", whole_first_argument=False
+        inspect.getsource(bundle_module._safe_relative),
+        "ValueError",
+        whole_first_argument=False,
     )
     raised |= _raised_codes(
         inspect.getsource(bundle_module._reject_secret_values),
-        "ValueError", whole_first_argument=False,
+        "ValueError",
+        whole_first_argument=False,
     )
     unlisted = raised - _SECTION_2E_CODES
     assert not unlisted, f"raised but not in §2e's table: {sorted(unlisted)}"
@@ -954,21 +1076,26 @@ def test_the_extraction_itself_finds_a_nonempty_set_in_every_source() -> None:
     contribute at least one code, not just the union as a whole."""
     preflight_codes = _raised_codes(
         Path(inspect.getfile(process_preflight_module)).read_text(encoding="utf-8"),
-        "PreflightError", whole_first_argument=True,
+        "PreflightError",
+        whole_first_argument=True,
     )
     bundle_v2_codes = _raised_codes(
         Path(inspect.getfile(bundle_v2_module)).read_text(encoding="utf-8"),
-        "ValueError", whole_first_argument=False,
+        "ValueError",
+        whole_first_argument=False,
     )
     assert "unknown_field" in preflight_codes  # the `return`-not-`raise` case (see module note).
     assert "compose_not_hosted" in preflight_codes
     assert len(bundle_v2_codes) > 10
     assert "bundle_path_unsafe" in _raised_codes(
-        inspect.getsource(bundle_module._safe_relative), "ValueError", whole_first_argument=False
+        inspect.getsource(bundle_module._safe_relative),
+        "ValueError",
+        whole_first_argument=False,
     )
     assert "resolved_secret_forbidden" in _raised_codes(
         inspect.getsource(bundle_module._reject_secret_values),
-        "ValueError", whole_first_argument=False,
+        "ValueError",
+        whole_first_argument=False,
     )
 
 
@@ -1000,41 +1127,51 @@ def _raised_codes_at_index(source_text: str, callee_name: str, *, index: int) ->
 
 
 # §2f's closed table (v1.8), transcribed verbatim, plus v1.10's two additions below.
-_SECTION_2F_CODES = frozenset({
-    "source_tree_unavailable", "build_failed", "runtime_unsupported", "spawn_failed",
-    "depends_on_timeout", "unsupported_capability_protocol",
-    # `seed_failed` (v1.10, §2f): a §2c migration/seed step exited nonzero against the freshly
-    # started store — customer-authored content, deterministic, `environment` domain (never
-    # retried). Landed in the frozen table this version; no longer an out-of-vocabulary flag.
-    "seed_failed",
-    # `store_statement_failed` (v1.10, §2f): a managed store errored or rejected a provisioner-
-    # ISSUED statement (CREATE/DROP/ALTER DATABASE, sentinel or canary probe) after passing
-    # readiness — the harness's own statements, so a deterministic failure here is a harness/
-    # engine fault, `infrastructure` domain (retryable), never `seed_failed` (that code is
-    # reserved for the customer's own migration/seed content).
-    "store_statement_failed",
-})
+_SECTION_2F_CODES = frozenset(
+    {
+        "source_tree_unavailable",
+        "build_failed",
+        "runtime_unsupported",
+        "spawn_failed",
+        "depends_on_timeout",
+        "unsupported_capability_protocol",
+        # `seed_failed` (v1.10, §2f): a §2c migration/seed step exited nonzero against the freshly
+        # started store — customer-authored content, deterministic, `environment` domain (never
+        # retried). Landed in the frozen table this version; no longer an out-of-vocabulary flag.
+        "seed_failed",
+        # `store_statement_failed` (v1.10, §2f): a managed store errored or rejected a provisioner-
+        # ISSUED statement (CREATE/DROP/ALTER DATABASE, sentinel or canary probe) after passing
+        # readiness — the harness's own statements, so a deterministic failure here is a harness/
+        # engine fault, `infrastructure` domain (retryable), never `seed_failed` (that code is
+        # reserved for the customer's own migration/seed content).
+        "store_statement_failed",
+    }
+)
 # `ProcessRuntimeError` also raises codes that are deliberately INTERNAL-only — each marks a
 # precondition `preflight_bundle` should already have made impossible (a placeholder token or a
 # missing credential preflight itself should have caught), so by the module's own docstring these
 # "never cross the outbound seam directly" and have no §2f entry to begin with. Excluded from
 # CONTAINMENT, not from extraction — a genuinely new internal code still surfaces in the raised
 # set for a human to classify, since only these documented names are exempted.
-_INTERNAL_ONLY_RUNTIME_CODES = frozenset({
-    "internal_unknown_placeholder", "internal_missing_credentials",
-    # Phase 6: marks a bundle-shape/state invariant an earlier layer (the model layer, or this
-    # module's own baseline-freeze-before-clone ordering) should already guarantee — e.g.
-    # `reset()` called before `provision()`, or a store's backing service turning out not to be a
-    # `ManagedProcess` despite `bundle_v2`'s `store_service_not_managed` check. A bug to fix here,
-    # never a bundle defect the outbound seam needs a name for — same status as the other two.
-    "internal_invariant_violated",
-})
+_INTERNAL_ONLY_RUNTIME_CODES = frozenset(
+    {
+        "internal_unknown_placeholder",
+        "internal_missing_credentials",
+        # Phase 6: marks a bundle-shape/state invariant an earlier layer (the model layer, or this
+        # module's own baseline-freeze-before-clone ordering) should already guarantee — e.g.
+        # `reset()` called before `provision()`, or a store's backing service turning out not to be a
+        # `ManagedProcess` despite `bundle_v2`'s `store_service_not_managed` check. A bug to fix here,
+        # never a bundle defect the outbound seam needs a name for — same status as the other two.
+        "internal_invariant_violated",
+    }
+)
 
 
 def test_every_section_2f_code_process_runtime_raises_is_in_the_closed_table() -> None:
     raised = _raised_codes_at_index(
         Path(inspect.getfile(process_runtime_module)).read_text(encoding="utf-8"),
-        "ProcessRuntimeError", index=1,
+        "ProcessRuntimeError",
+        index=1,
     )
     # `process_name_invalid` (F3's defense-in-depth path-containment check, `_ensure_within`) is
     # not a NEW §2f code — it deliberately reuses the EXISTING §2e model-layer code as a backstop
@@ -1042,15 +1179,15 @@ def test_every_section_2f_code_process_runtime_raises_is_in_the_closed_table() -
     # just §2f's own six entries.
     unlisted = raised - _SECTION_2F_CODES - _SECTION_2E_CODES - _INTERNAL_ONLY_RUNTIME_CODES
     assert not unlisted, (
-        f"raised but not in §2f's table (nor §2e's, nor a documented internal-only code): "
-        f"{sorted(unlisted)}"
+        f"raised but not in §2f's table (nor §2e's, nor a documented internal-only code): {sorted(unlisted)}"
     )
 
 
 def test_the_section_2f_extraction_itself_finds_a_nonempty_set() -> None:
     raised = _raised_codes_at_index(
         Path(inspect.getfile(process_runtime_module)).read_text(encoding="utf-8"),
-        "ProcessRuntimeError", index=1,
+        "ProcessRuntimeError",
+        index=1,
     )
     assert "build_failed" in raised
     assert "spawn_failed" in raised

--- a/tests/harness/test_process_runtime.py
+++ b/tests/harness/test_process_runtime.py
@@ -701,6 +701,22 @@ def test_select_process_secrets_hard_excludes_source_checkout_even_if_claimed() 
     assert selected == {"A": "target-provider-value"}
 
 
+def test_select_process_secrets_hard_excludes_simulator_provider_even_if_claimed() -> (
+    None
+):
+    """Untrusted bundle processes must never receive Future AGI simulator credentials."""
+    process = _source_process(secret_purposes=["target_provider", "simulator_provider"])
+    selected = pr.select_process_secrets(
+        process,
+        secret_values={"AGENT_KEY": "customer", "SIM_KEY": "futureagi"},
+        secret_purposes={
+            "AGENT_KEY": "target_provider",
+            "SIM_KEY": "simulator_provider",
+        },
+    )
+    assert selected == {"AGENT_KEY": "customer"}
+
+
 # --- env construction (F12/F14) -----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- add a dedicated simulator_provider secret purpose for hosted control-plane credentials
- keep hosted simulator credentials separate from customer target-provider values
- prevent customer processes from claiming or receiving simulator credentials
- retain local SDK and CLI BYOK behavior
- update unified hosted authoring to consume only platform-owned SIMULATOR_ aliases

## Validation
- 365 focused ALK harness tests passed
- Ruff and diff checks passed

## Security boundary
Customer target processes receive only target_provider values. Simulator credentials remain control-plane owned and are excluded from process-runtime injection.