### PR TITLE
fix(harness): harden hosted callback agent execution

### DIFF
--- a/Dockerfile.hosted
+++ b/Dockerfile.hosted
@@ -72,7 +72,7 @@ WORKDIR /opt/alk
 # Daytona's direct-image builder can reuse an image when only build-context
 # files change.  Bump this source revision whenever guest code changes so a
 # hosted test cannot silently execute an older installed ALK.
-ARG ALK_HOSTED_SOURCE_REVISION=20260829-visible-diagnostics-r12
+ARG ALK_HOSTED_SOURCE_REVISION=20260831-callback-runtime-r13
 LABEL io.futureagi.alk-source-revision="${ALK_HOSTED_SOURCE_REVISION}"
 COPY pyproject.toml README.md ./
 COPY src ./src

--- a/Dockerfile.hosted
+++ b/Dockerfile.hosted
@@ -72,7 +72,7 @@ WORKDIR /opt/alk
 # Daytona's direct-image builder can reuse an image when only build-context
 # files change.  Bump this source revision whenever guest code changes so a
 # hosted test cannot silently execute an older installed ALK.
-ARG ALK_HOSTED_SOURCE_REVISION=20260831-callback-runtime-r13
+ARG ALK_HOSTED_SOURCE_REVISION=20260901-process-group-cleanup-r17
 LABEL io.futureagi.alk-source-revision="${ALK_HOSTED_SOURCE_REVISION}"
 COPY pyproject.toml README.md ./
 COPY src ./src

--- a/src/fi/alk/harness/bundle_author_v2.py
+++ b/src/fi/alk/harness/bundle_author_v2.py
@@ -9,6 +9,7 @@ result, and runs the guest's exact preflight before publishing it.
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import json
 import re
@@ -491,6 +492,42 @@ def _dockerfile_run(root: Path) -> list[str] | None:
     return argv
 
 
+def _callback_entrypoint(root: Path) -> str:
+    """Find the one repository callback promised by a callable runtime contract."""
+    candidates: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        relative = path.relative_to(root)
+        if any(part in _IGNORED_ARTIFACT_PARTS for part in relative.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        if any(
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "agent_callback"
+            for node in tree.body
+        ):
+            module = ".".join(relative.with_suffix("").parts)
+            candidates.append(f"{module}:agent_callback")
+    if not candidates:
+        raise BundleAuthorError(
+            "callback_entrypoint_missing: callable runtime requires one module-level "
+            "agent_callback"
+        )
+    if len(candidates) != 1:
+        raise BundleAuthorError(
+            "callback_entrypoint_ambiguous: " + ", ".join(candidates)
+        )
+    return candidates[0]
+
+
+def _callback_adapter_source() -> str:
+    return (
+        Path(__file__).with_name("callback_http_adapter.py").read_text(encoding="utf-8")
+    )
+
+
 def _managed_world_db() -> ManagedProcess:
     return ManagedProcess(
         name="world-db",
@@ -522,6 +559,7 @@ def resolve_environment_plan(
     job: HarnessJob,
     *,
     contract_modality: str | None = None,
+    contract_interface_kind: str | None = None,
 ) -> EnvironmentPlanV2:
     """Resolve packaging once.  Authoring and provisioning consume this same immutable plan."""
     root = Path(source).resolve()
@@ -732,8 +770,11 @@ def resolve_environment_plan(
             )
         packaging = "compose"
     else:
+        is_callback = (contract_interface_kind or "").strip().lower().replace(
+            "-", "_"
+        ) == "callable"
         entry = "agent.py"
-        if not (root / entry).is_file():
+        if not is_callback and not (root / entry).is_file():
             candidates = sorted(root.glob("**/agent.py"))
             if len(candidates) != 1:
                 raise BundleAuthorError(
@@ -754,18 +795,34 @@ def resolve_environment_plan(
             if is_livekit
             else {}
         )
+        callback_entrypoint = _callback_entrypoint(root) if is_callback else None
+        if callback_entrypoint:
+            environment.update(
+                {
+                    "PORT": "{{PORT_agent}}",
+                    "ALK_CALLBACK_ENTRYPOINT": callback_entrypoint,
+                }
+            )
         process = _plan_python(
             root,
             name=control_name,
-            root=component,
+            root=root if is_callback else component,
             entry=entry,
             control=True,
             needs_secrets=needs_target_secrets,
             port=port,
             environment=environment,
             livekit_download=is_livekit,
-            run_override=_dockerfile_run(component),
+            run_override=(None if is_callback else _dockerfile_run(component)),
         )
+        if is_callback:
+            python_command = process.run_command[:-1]
+            process = process.model_copy(
+                update={
+                    "run_command": python_command + ["-c", _callback_adapter_source()],
+                    "started_check": StartedCheck(port=True, timeout_seconds=180),
+                }
+            )
         if is_livekit:
             process = process.model_copy(
                 update={
@@ -884,6 +941,7 @@ def author_bundle_v2(
     authoring_root = Path(authoring).resolve()
     output_root = Path(output).resolve()
     contract_modality: str | None = None
+    contract_interface_kind: str | None = None
     contract_path = authoring_root / "contract.json"
     if contract_path.is_file():
         try:
@@ -895,10 +953,15 @@ def author_bundle_v2(
         if not isinstance(contract_body, dict):
             raise BundleAuthorError("contract_invalid: contract.json must be an object")
         contract_modality = str(contract_body.get("modality") or "").strip().lower()
+        runtime = contract_body.get("runtime")
+        interface = runtime.get("interface") if isinstance(runtime, dict) else None
+        if isinstance(interface, dict):
+            contract_interface_kind = str(interface.get("kind") or "").strip().lower()
     plan = resolve_environment_plan(
         source_root,
         job,
         contract_modality=contract_modality,
+        contract_interface_kind=contract_interface_kind,
     )
     output_root.parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(

--- a/src/fi/alk/harness/call_runner.py
+++ b/src/fi/alk/harness/call_runner.py
@@ -179,48 +179,59 @@ class _MissingVoiceConfig:
 
 
 def _check_config(
-    job: HarnessJob, target_provider_secret_values: Mapping[str, str]
+    job: HarnessJob,
+    target_provider_secret_values: Mapping[str, str],
+    simulator_values: Mapping[str, str] | None = None,
 ) -> _MissingVoiceConfig | None:
+    simulator_values = simulator_values or {}
+
+    def simulator_value(alias: str) -> str | None:
+        # Hosted runs supply platform-owned simulator credentials in the control process.  The
+        # target-provider value remains a backwards-compatible fallback for local SDK callers.
+        return simulator_values.get(alias) or target_provider_secret_values.get(alias)
+
     config = job.agent.config
     llm_provider = str(
         config.get("simulator_llm_provider")
-        or target_provider_secret_values.get(SIMULATOR_LLM_PROVIDER_ALIAS)
+        or simulator_value(SIMULATOR_LLM_PROVIDER_ALIAS)
         or "google"
     ).lower()
     stt_provider = str(
         config.get("simulator_stt_provider")
-        or target_provider_secret_values.get(SIMULATOR_STT_PROVIDER_ALIAS)
+        or simulator_value(SIMULATOR_STT_PROVIDER_ALIAS)
         or "deepgram"
     ).lower()
     tts_provider = str(
         config.get("simulator_tts_provider")
-        or target_provider_secret_values.get(SIMULATOR_TTS_PROVIDER_ALIAS)
+        or simulator_value(SIMULATOR_TTS_PROVIDER_ALIAS)
         or "deepgram"
     ).lower()
 
     required = [LIVEKIT_API_KEY_ALIAS, LIVEKIT_API_SECRET_ALIAS]
     if "deepgram" in {stt_provider, tts_provider}:
-        required.append(DEEPGRAM_API_KEY_ALIAS)
+        if not simulator_value(DEEPGRAM_API_KEY_ALIAS):
+            required.append(DEEPGRAM_API_KEY_ALIAS)
     missing_aliases = [
         alias for alias in required if not target_provider_secret_values.get(alias)
     ]
 
     if llm_provider == "google":
         has_api_key = bool(
-            target_provider_secret_values.get(GEMINI_API_KEY_ALIAS)
-            or target_provider_secret_values.get(GOOGLE_API_KEY_ALIAS)
+            simulator_value(GEMINI_API_KEY_ALIAS)
+            or simulator_value(GOOGLE_API_KEY_ALIAS)
         )
         has_vertex_adc = bool(
-            target_provider_secret_values.get(GOOGLE_APPLICATION_CREDENTIALS_JSON_ALIAS)
-            and target_provider_secret_values.get(GOOGLE_CLOUD_PROJECT_ALIAS)
+            (
+                simulator_value(GOOGLE_APPLICATION_CREDENTIALS_ALIAS)
+                or simulator_value(GOOGLE_APPLICATION_CREDENTIALS_JSON_ALIAS)
+            )
+            and simulator_value(GOOGLE_CLOUD_PROJECT_ALIAS)
         )
         if not has_api_key and not has_vertex_adc:
             missing_aliases.append(
                 f"{GEMINI_API_KEY_ALIAS}_or_{GOOGLE_API_KEY_ALIAS}_or_VERTEX_ADC"
             )
-    elif llm_provider == "openai" and not target_provider_secret_values.get(
-        OPENAI_API_KEY_ALIAS
-    ):
+    elif llm_provider == "openai" and not simulator_value(OPENAI_API_KEY_ALIAS):
         missing_aliases.append(OPENAI_API_KEY_ALIAS)
 
     has_livekit_url = bool(
@@ -608,6 +619,11 @@ class CallRunnerImpl:
             LIVEKIT_API_KEY_ALIAS,
             LIVEKIT_API_SECRET_ALIAS,
             LIVEKIT_URL_ALIAS,
+        ):
+            value = context.target_provider_secret_values.get(alias)
+            if value:
+                target_environ[alias] = value
+        for alias in (
             DEEPGRAM_API_KEY_ALIAS,
             CARTESIA_API_KEY_ALIAS,
             GEMINI_API_KEY_ALIAS,
@@ -626,7 +642,9 @@ class CallRunnerImpl:
         ):
             value = context.target_provider_secret_values.get(alias)
             if value:
-                target_environ[alias] = value
+                # Platform-owned simulator credentials already present in the hosted control
+                # process win.  Target credentials are retained only as the local-SDK fallback.
+                target_environ.setdefault(alias, value)
         self._environ = target_environ
         self._adc_path = _materialize_vertex_adc(
             context.target_provider_secret_values,
@@ -640,7 +658,7 @@ class CallRunnerImpl:
             or ""
         )
         self._missing_config = _check_config(
-            context.job, context.target_provider_secret_values
+            context.job, context.target_provider_secret_values, target_environ
         )
         self._scenario_attempt_counts: dict[str, int] = {}
 

--- a/src/fi/alk/harness/callback_http_adapter.py
+++ b/src/fi/alk/harness/callback_http_adapter.py
@@ -1,0 +1,96 @@
+"""HTTP bridge embedded into hosted bundles for ``fi.simulate`` callbacks.
+
+The bundle producer serializes this module into the process command.  It deliberately uses only
+the standard library plus the submitted agent's own ``fi.simulate`` dependency, so a callback-only
+repository does not need to be modified or taught about the hosted process runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+def _load_callback() -> Any:
+    target = os.environ["ALK_CALLBACK_ENTRYPOINT"]
+    module_name, separator, attribute = target.partition(":")
+    if not separator or not module_name or not attribute:
+        raise RuntimeError(f"invalid ALK_CALLBACK_ENTRYPOINT: {target!r}")
+    callback = getattr(importlib.import_module(module_name), attribute)
+    if not callable(callback):
+        raise RuntimeError(f"callback entrypoint is not callable: {target!r}")
+    return callback
+
+
+CALLBACK = _load_callback()
+
+
+def _json_body(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        body = value.model_dump(mode="json", exclude_none=True)
+    elif isinstance(value, dict):
+        body = value
+    else:
+        body = {"content": str(value)}
+    if not isinstance(body, dict):
+        raise TypeError("callback response must serialize to a JSON object")
+    body.setdefault("content", "")
+    return body
+
+
+def _invoke(payload: dict[str, Any]) -> dict[str, Any]:
+    from fi.simulate import AgentInput
+
+    result = CALLBACK(AgentInput.model_validate(payload))
+    if inspect.isawaitable(result):
+        result = asyncio.run(result)
+    return _json_body(result)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _respond(self, status: int, body: dict[str, Any]) -> None:
+        encoded = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path.rstrip("/") == "/health":
+            self._respond(200, {"status": "ok"})
+        else:
+            self._respond(404, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path.rstrip("/") != "/invoke":
+            self._respond(404, {"error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length) or b"{}")
+            if not isinstance(payload, dict):
+                raise TypeError("request body must be a JSON object")
+            self._respond(200, _invoke(payload))
+        except Exception as exc:  # noqa: BLE001 - target errors cross the HTTP seam
+            self._respond(
+                500,
+                {"error": f"{type(exc).__name__}: {exc}", "content": ""},
+            )
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+def main() -> None:
+    port = int(os.environ.get("PORT", "8080"))
+    ThreadingHTTPServer(("0.0.0.0", port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fi/alk/harness/chat_call_runner.py
+++ b/src/fi/alk/harness/chat_call_runner.py
@@ -149,7 +149,7 @@ def _tool_call(call: dict[str, Any], index: int) -> tuple[str, dict[str, Any], s
 
 
 class HostedChatCallRunner:
-    """Drive an OpenAI-compatible repository HTTP endpoint inside its leased world."""
+    """Drive a repository chat ingress inside its leased world."""
 
     def __init__(self, adapter: ArtifactUploader, context: CallRunnerContext) -> None:
         self._adapter = adapter
@@ -177,9 +177,9 @@ class HostedChatCallRunner:
                 "chat_contract_unavailable: bundle/contract.json is absent"
             )
         interface = self._contract.runtime.interface if self._contract.runtime else None
-        if interface is None or interface.kind != "http":
+        if interface is None or interface.kind not in {"http", "callable"}:
             raise CallAborted(
-                "chat_interface_unsupported: an HTTP runtime interface is required"
+                "chat_interface_unsupported: an HTTP or callable runtime interface is required"
             )
         endpoint = runtime.endpoints.get("target_http")
         if endpoint is None:
@@ -197,11 +197,15 @@ class HostedChatCallRunner:
             runtime,
             self._context.source_directory,
         )
+        adapter_path = "/invoke" if interface.kind == "callable" else interface.path
+        adapter_protocol = (
+            "fi.alk" if interface.kind == "callable" else interface.protocol
+        )
         wrapper = HTTPAgentWrapper(
             endpoint=urljoin(
-                endpoint.address.rstrip("/") + "/", interface.path.lstrip("/")
+                endpoint.address.rstrip("/") + "/", adapter_path.lstrip("/")
             ),
-            protocol=interface.protocol,
+            protocol=adapter_protocol,
             include_tools=interface.include_tools,
             timeout=30.0,
             metadata={
@@ -259,6 +263,19 @@ class HostedChatCallRunner:
                             else f"no such tool {name}",
                         }
                     )
+                provided_ids = {
+                    str(item.get("tool_call_id") or "")
+                    for item in response.tool_responses or []
+                    if isinstance(item, dict)
+                }
+                returned_ids = {
+                    _tool_call(call, index)[2]
+                    for index, call in enumerate(returned, start=1)
+                }
+                if returned_ids and returned_ids.issubset(provided_ids):
+                    answer = response.content.strip()
+                    messages.append({"role": "assistant", "content": answer})
+                    break
             else:
                 raise CallAborted("chat_target_failed: exceeded 8 tool continuations")
         except CallAborted:

--- a/src/fi/alk/harness/chat_call_runner.py
+++ b/src/fi/alk/harness/chat_call_runner.py
@@ -17,6 +17,8 @@ from .contract import AgentContract
 from .hosted_scheduler import CallAborted, CallOutcome, Scenario, World
 from .outbound import ArtifactKind, format_rfc3339_millis
 from .process_runtime import EnvironmentRuntime
+from .run.conversation import Transcript, converse
+from .scenario import Scenario as ConversationScenario
 from .world.runtime import GeneratedWorld
 from .world.stores.postgres import AttachedPostgresStore
 
@@ -148,6 +150,144 @@ def _tool_call(call: dict[str, Any], index: int) -> tuple[str, dict[str, Any], s
     return name, arguments, str(call.get("id") or f"call_{index}")
 
 
+class _HostedChatTarget:
+    """The already-running Bundle V2 chat process, exposed as the normal conversation target.
+
+    ``converse`` owns the simulated customer's turns.  This target owns only the submitted
+    agent's side of the exchange and response-carried tool evidence.  Keeping that split identical
+    to the local repository target prevents the hosted lane from silently becoming a one-message
+    smoke test again.
+    """
+
+    key = "hosted_repository"
+
+    def __init__(
+        self,
+        *,
+        wrapper: Any,
+        contract: AgentContract,
+        world: GeneratedWorld,
+        scenario_key: str,
+        scenario_id: str,
+    ) -> None:
+        self._wrapper = wrapper
+        self._contract = contract
+        self.world = world
+        self._scenario_key = scenario_key
+        self._scenario_id = scenario_id
+        self._messages: list[dict[str, Any]] = []
+        self._turn = 0
+
+    async def open(self) -> None:
+        return
+
+    async def say(self, utterance: str) -> str:
+        self._messages.append({"role": "user", "content": utterance})
+        for continuation in range(8):
+            response = await self._wrapper.call(
+                AgentInput(
+                    thread_id=self._scenario_key,
+                    execution_id=self._scenario_id,
+                    turn_index=self._turn,
+                    scenario_name=self._scenario_key,
+                    modality="text",
+                    messages=list(self._messages),
+                    new_message=dict(self._messages[-1]),
+                    tools=_tools(self._contract)
+                    if self._contract.runtime
+                    and self._contract.runtime.interface
+                    and self._contract.runtime.interface.include_tools
+                    else [],
+                )
+            )
+            trace = dict((response.metadata or {}).get("external_agent") or {})
+            if trace and not trace.get("success", False):
+                raise RuntimeError(
+                    str(trace.get("error") or "submitted endpoint request failed")
+                )
+            returned = list(response.tool_calls or [])
+            if not returned:
+                answer = response.content.strip()
+                self._messages.append({"role": "assistant", "content": answer})
+                self._turn += 1
+                return answer
+
+            self._messages.append(
+                {
+                    "role": "assistant",
+                    "content": response.content or "",
+                    "tool_calls": returned,
+                }
+            )
+            returned_ids: set[str] = set()
+            for index, call in enumerate(returned, start=1):
+                name, arguments, call_id = _tool_call(call, index)
+                returned_ids.add(call_id)
+                result = self.world.handle_tool_call(
+                    {"id": call_id, "name": name, "arguments": arguments}
+                )
+                self._messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call_id,
+                        "name": name,
+                        "content": result.content
+                        if result is not None
+                        else f"no such tool {name}",
+                    }
+                )
+
+            # A callback-backed repository has already run its own real tools.  It returns their
+            # responses beside the final text; replaying the calls above records deterministic
+            # evidence in the generated world, but asking the callback a second time would run the
+            # tools twice.  HTTP agents that only return requests continue normally with the
+            # generated-world responses appended above.
+            provided_ids = {
+                str(item.get("tool_call_id") or "")
+                for item in response.tool_responses or []
+                if isinstance(item, dict)
+            }
+            if returned_ids and returned_ids.issubset(provided_ids):
+                answer = response.content.strip()
+                self._messages.append({"role": "assistant", "content": answer})
+                self._turn += 1
+                return answer
+        raise RuntimeError("submitted chat agent exceeded 8 tool continuations in one turn")
+
+    async def close(self) -> None:
+        return
+
+    @property
+    def spent_usd(self) -> float:
+        # Provider-side target cost is not observable at this transport seam.
+        return 0.0
+
+
+def _conversation_scenario(document: dict[str, Any]) -> ConversationScenario:
+    try:
+        normalized = dict(document)
+        normalized.setdefault(
+            "name", str(normalized.get("scenario_key") or "hosted-chat-scenario")
+        )
+        return ConversationScenario.model_validate(normalized)
+    except Exception as exc:  # noqa: BLE001 - normalize malformed bundle content at the call seam
+        raise CallAborted(f"chat_scenario_invalid: {exc}") from exc
+
+
+async def _drive_conversation(
+    target: _HostedChatTarget,
+    scenario: ConversationScenario,
+    contract: AgentContract,
+    bundle_dir: Path,
+) -> Transcript:
+    return await converse(
+        target,
+        scenario,
+        contract,
+        world_root=bundle_dir,
+    )
+
+
 class HostedChatCallRunner:
     """Drive a repository chat ingress inside its leased world."""
 
@@ -188,8 +328,8 @@ class HostedChatCallRunner:
             )
 
         document = _scenario_document(self._context.bundle_dir, scenario.scenario_key)
-        instruction = str(document.get("instruction") or "").strip()
-        if not instruction:
+        conversation_scenario = _conversation_scenario(document)
+        if not conversation_scenario.instruction.strip():
             raise CallAborted("chat_scenario_invalid: instruction is empty")
         target_world = _tool_world(
             self._context.bundle_dir,
@@ -213,84 +353,33 @@ class HostedChatCallRunner:
                 "scenario": scenario.scenario_key,
             },
         )
-        messages: list[dict[str, Any]] = [{"role": "user", "content": instruction}]
         started = datetime.now(timezone.utc)
-        answer = ""
         try:
-            for continuation in range(8):
-                response = await wrapper.call(
-                    AgentInput(
-                        thread_id=scenario.scenario_key,
-                        execution_id=scenario.scenario_id,
-                        turn_index=continuation,
-                        scenario_name=scenario.scenario_key,
-                        modality="text",
-                        messages=list(messages),
-                        new_message=dict(messages[-1]),
-                        tools=_tools(self._contract) if interface.include_tools else [],
-                    )
-                )
-                trace = dict((response.metadata or {}).get("external_agent") or {})
-                if trace and not trace.get("success", False):
-                    raise CallAborted(
-                        "chat_target_failed: "
-                        + str(trace.get("error") or "submitted endpoint request failed")
-                    )
-                returned = list(response.tool_calls or [])
-                if not returned:
-                    answer = response.content.strip()
-                    messages.append({"role": "assistant", "content": answer})
-                    break
-                messages.append(
-                    {
-                        "role": "assistant",
-                        "content": response.content or "",
-                        "tool_calls": returned,
-                    }
-                )
-                for index, call in enumerate(returned, start=1):
-                    name, arguments, call_id = _tool_call(call, index)
-                    result = target_world.handle_tool_call(
-                        {"id": call_id, "name": name, "arguments": arguments}
-                    )
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call_id,
-                            "name": name,
-                            "content": result.content
-                            if result is not None
-                            else f"no such tool {name}",
-                        }
-                    )
-                provided_ids = {
-                    str(item.get("tool_call_id") or "")
-                    for item in response.tool_responses or []
-                    if isinstance(item, dict)
-                }
-                returned_ids = {
-                    _tool_call(call, index)[2]
-                    for index, call in enumerate(returned, start=1)
-                }
-                if returned_ids and returned_ids.issubset(provided_ids):
-                    answer = response.content.strip()
-                    messages.append({"role": "assistant", "content": answer})
-                    break
-            else:
-                raise CallAborted("chat_target_failed: exceeded 8 tool continuations")
+            transcript = await _drive_conversation(
+                _HostedChatTarget(
+                    wrapper=wrapper,
+                    contract=self._contract,
+                    world=target_world,
+                    scenario_key=scenario.scenario_key,
+                    scenario_id=scenario.scenario_id,
+                ),
+                conversation_scenario,
+                self._contract,
+                self._context.bundle_dir,
+            )
         except CallAborted:
             raise
         except Exception as exc:  # noqa: BLE001 - convert target transport failures to call faults
-            raise CallAborted(f"chat_call_failed: {type(exc).__name__}: {exc}") from exc
+            raise CallAborted(f"chat_target_failed: {type(exc).__name__}: {exc}") from exc
 
         ended = datetime.now(timezone.utc)
-        transcript = f"customer: {instruction}\nagent: {answer or '(said nothing)'}\n"
+        rendered_transcript = transcript.spoken() + "\n"
         transcript_id = await self._adapter.upload_artifact(
-            transcript.encode("utf-8"),
+            rendered_transcript.encode("utf-8"),
             kind=ArtifactKind.TRANSCRIPT,
             scenario_key=scenario.scenario_key,
         )
-        calls = tuple(target_world.calls)
+        calls = tuple(transcript.calls)
         if calls:
             tool_trace = "\n".join(
                 json.dumps(
@@ -315,7 +404,7 @@ class HostedChatCallRunner:
             )
         return CallOutcome(
             calls=calls,
-            turns=2,
+            turns=len(transcript.exchanges),
             started_at=format_rfc3339_millis(started),
             ended_at=format_rfc3339_millis(ended),
             duration_ms=_duration_ms(started, ended),

--- a/src/fi/alk/harness/hosted_entrypoint.py
+++ b/src/fi/alk/harness/hosted_entrypoint.py
@@ -23,6 +23,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import random
 import signal
 import time
@@ -116,6 +117,35 @@ EVENTS_SPOOL_DIR_NAME = (
 )
 
 SECRETS_PATH = Path("/run/futureagi/secrets.json")
+SIMULATOR_SECRETS_PATH = Path("/run/futureagi/simulator-secrets.json")
+
+# Platform-owned simulator configuration is delivered on a separate control-plane channel.  It
+# must never be confused with the customer's ``target_provider`` refs, which are selectively
+# injected into the untrusted agent processes by ProcessRuntimeProvider.  These names are the
+# complete set the in-process text/voice simulators may consume.
+_SIMULATOR_SECRET_ALIASES = frozenset(
+    {
+        "ALK_HARNESS",
+        "ALK_HARNESS_MODEL",
+        "ALK_HARNESS_THINKING",
+        "ALK_VERTEX_LOCATION",
+        "CARTESIA_API_KEY",
+        "DEEPGRAM_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_GENAI_USE_VERTEXAI",
+        "OPENAI_API_KEY",
+        "SIMULATOR_LLM_MODEL",
+        "SIMULATOR_LLM_PROVIDER",
+        "SIMULATOR_STT_MODEL",
+        "SIMULATOR_STT_PROVIDER",
+        "SIMULATOR_TTS_MODEL",
+        "SIMULATOR_TTS_PROVIDER",
+    }
+)
 
 
 # =================================================================================================
@@ -186,6 +216,32 @@ def peek_target_provider_secret_values(
         str(alias): str(value)
         for alias, value in raw.items()
         if secret_purposes.get(str(alias)) == "target_provider"
+    }
+
+
+def load_simulator_secret_values(path: Path) -> dict[str, str]:
+    """Load and immediately remove the platform-owned simulator secret channel.
+
+    The fixed allowlist is deliberate: a platform deployment cannot accidentally use this file
+    to inject arbitrary ambient variables into the control process.  Agent subprocesses still do
+    not inherit these values because ``process_runtime`` starts them from its closed environment
+    allowlist plus purpose-matched target secrets.
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    finally:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("simulator-secrets.json unlink failed: %s", exc)
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(alias): str(value)
+        for alias, value in raw.items()
+        if str(alias) in _SIMULATOR_SECRET_ALIASES and value not in (None, "")
     }
 
 
@@ -1443,6 +1499,9 @@ class HostedEntrypointDeps:
     clock: Callable[[], datetime] = field(default=lambda: datetime.now(timezone.utc))
     cancel_path: Path = field(default_factory=lambda: Path(CANCEL_SIGNAL_PATH))
     secrets_path: Path = field(default_factory=lambda: SECRETS_PATH)
+    simulator_secrets_path: Path = field(
+        default_factory=lambda: SIMULATOR_SECRETS_PATH
+    )
     flush_window_seconds: float = ob.FLUSH_WINDOW_SECONDS
     install_sigterm_handler: Callable[[CancelState], Callable[[], None]] = field(
         default=default_install_sigterm_handler
@@ -1475,6 +1534,9 @@ class HostedEntrypointDeps:
         self, secret_purposes: dict[str, str]
     ) -> dict[str, str]:
         return peek_target_provider_secret_values(self.secrets_path, secret_purposes)
+
+    def load_simulator_secret_values(self) -> dict[str, str]:
+        return load_simulator_secret_values(self.simulator_secrets_path)
 
 
 # =================================================================================================
@@ -1552,6 +1614,12 @@ async def run_job(
     deps = deps or HostedEntrypointDeps()
     work_directory = output.parent
 
+    # This control-process-only channel is loaded before any Stage or CallRunner is constructed.
+    # It is separate from secrets.json so platform simulator credentials never acquire the
+    # ``target_provider`` purpose and therefore can never enter an agent process.
+    simulator_secret_values = deps.load_simulator_secret_values()
+    os.environ.update(simulator_secret_values)
+
     # 1. Boot -- capabilities. CapabilitiesError -> exit non-zero-and-NOT-3, no event (v1.3 table):
     # there is no channel yet to report a terminal event through.
     try:
@@ -1588,7 +1656,10 @@ async def run_job(
         results_client=results_client,
         artifacts_client=artifacts_client,
         channel_state=channel_state,
-        extra_secret_values=deps.peek_secret_values(),
+        extra_secret_values=(
+            *deps.peek_secret_values(),
+            *tuple(simulator_secret_values.values()),
+        ),
         clock=deps.clock,
         flush_window_seconds=deps.flush_window_seconds,
     )

--- a/src/fi/alk/harness/process_runtime.py
+++ b/src/fi/alk/harness/process_runtime.py
@@ -996,10 +996,12 @@ class PopenProcess:
             return ""
 
     def terminate(self) -> None:
-        self.popen.terminate()
+        self._signal_process_group(signal.SIGTERM, self.popen.terminate)
 
     def interrupt(self) -> None:
-        self.popen.send_signal(signal.SIGINT)
+        self._signal_process_group(
+            signal.SIGINT, lambda: self.popen.send_signal(signal.SIGINT)
+        )
 
     def wait(self, timeout: float) -> bool:
         try:
@@ -1009,7 +1011,24 @@ class PopenProcess:
             return False
 
     def kill(self) -> None:
-        self.popen.kill()
+        self._signal_process_group(signal.SIGKILL, self.popen.kill)
+
+    def _signal_process_group(
+        self, signum: int, fallback: Callable[[], None]
+    ) -> None:
+        """Stop the complete runtime process, including launcher descendants.
+
+        Source commands commonly use launchers such as ``uv run``, ``npm``, or shell
+        scripts. Signalling only the launcher leaves its actual server orphaned and a
+        subsequent world reset cannot bind the same port. ``default_process_runner``
+        gives every process its own session, so its pid is also the process-group id.
+        Keep the direct-Popen fallback for synthetic handles and platforms without
+        ``killpg``.
+        """
+        try:
+            os.killpg(self.popen.pid, signum)
+        except (AttributeError, OSError):
+            fallback()
 
 
 _TERMINATE_WAIT_SECONDS = 5.0
@@ -1108,6 +1127,10 @@ def default_process_runner(
         stderr=subprocess.STDOUT,
         user=user,
         group=group,
+        # Each declared runtime process owns a process group. This is necessary for
+        # deterministic reset/cleanup when the command is a launcher which forks the
+        # real long-lived server (for example ``uv run`` or ``npm start``).
+        start_new_session=True,
     )
     return PopenProcess(popen=popen, log_path=log_path)
 

--- a/src/fi/simulate/agent/wrappers/http.py
+++ b/src/fi/simulate/agent/wrappers/http.py
@@ -118,7 +118,7 @@ class HTTPAgentWrapper(AgentWrapper):
         return response
 
     def _request_payload(self, input: AgentInput) -> dict[str, Any]:
-        messages = list(input.messages)
+        messages = _messages_for_protocol(input.messages, self.protocol)
         if self.system_prompt:
             messages = [{"role": "system", "content": self.system_prompt}, *messages]
         if self.protocol == "openai_chat":
@@ -225,6 +225,30 @@ def _normalize_protocol(value: str) -> str:
     return protocol
 
 
+def _messages_for_protocol(
+    messages: Sequence[Mapping[str, Any]], protocol: str
+) -> list[dict[str, Any]]:
+    """Encode canonical ALK history for the selected external-agent protocol.
+
+    ALK keeps tool calls structured internally. OpenAI-compatible endpoints require that array
+    unchanged, while the FutureAGI callback ``AgentInput`` schema represents historical
+    ``tool_calls`` as a JSON string. Normalizing here keeps the conversation runner generic and
+    prevents a retry from accidentally executing a side-effecting tool twice.
+    """
+    normalized = [dict(message) for message in messages]
+    if protocol != "fi.alk":
+        return normalized
+    for message in normalized:
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, Sequence) and not isinstance(
+            tool_calls, (str, bytes)
+        ):
+            message["tool_calls"] = json.dumps(
+                list(tool_calls), separators=(",", ":"), default=str
+            )
+    return normalized
+
+
 def _openai_tool_spec(tool: Mapping[str, Any]) -> dict[str, Any]:
     # Accept both the flat SDK tool shape ({name, description, parameters}) and
     # the OpenAI-nested shape ({"type": "function", "function": {...}}). Without
@@ -233,7 +257,11 @@ def _openai_tool_spec(tool: Mapping[str, Any]) -> dict[str, Any]:
     # real tool and the environment's mock never matches.
     fn = tool.get("function") if isinstance(tool.get("function"), Mapping) else {}
     name = str(
-        tool.get("name") or fn.get("name") or tool.get("tool") or tool.get("id") or "tool"
+        tool.get("name")
+        or fn.get("name")
+        or tool.get("tool")
+        or tool.get("id")
+        or "tool"
     )
     parameters = tool.get("parameters")
     if not isinstance(parameters, Mapping):

--- a/tests/harness/test_bundle_author_v2.py
+++ b/tests/harness/test_bundle_author_v2.py
@@ -68,6 +68,25 @@ def _write_voice_contract(authoring: Path) -> None:
     )
 
 
+def _write_callable_contract(authoring: Path) -> None:
+    (authoring / "contract.json").write_text(
+        json.dumps(
+            {
+                "modality": "chat",
+                "runtime": {
+                    "language": "python",
+                    "interface": {
+                        "kind": "callable",
+                        "protocol": "fi.alk",
+                        "include_tools": True,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_auto_voice_contract_compiles_livekit_process_runtime(tmp_path: Path) -> None:
     source = tmp_path / "voice-agent"
     source.mkdir()
@@ -88,6 +107,67 @@ def test_auto_voice_contract_compiles_livekit_process_runtime(tmp_path: Path) ->
     assert agent.environment["LIVEKIT_AGENT_NAME"].endswith("-w{{WORLD_INDEX}}")
     assert "target_provider" in agent.secret_purposes
     assert "target_http" not in bundle.capabilities
+
+
+def test_callable_contract_compiles_repository_callback_adapter(tmp_path: Path) -> None:
+    source = tmp_path / "ava"
+    app = source / "app"
+    app.mkdir(parents=True)
+    (app / "__init__.py").write_text("", encoding="utf-8")
+    (app / "agent.py").write_text(
+        "async def agent_callback(input):\n"
+        "    return {'content': input.new_message['content']}\n\n"
+        "if __name__ == '__main__':\n"
+        "    print(input('you> '))\n",
+        encoding="utf-8",
+    )
+    (source / "requirements.txt").write_text("agent-simulate\n", encoding="utf-8")
+    authoring = _authoring(tmp_path)
+    _write_callable_contract(authoring)
+
+    bundle = author_bundle_v2(
+        source=source,
+        job=_job(connector="auto", with_secrets=True),
+        authoring=authoring,
+        output=tmp_path / "bundle",
+    )
+
+    agent = next(process for process in bundle.processes if process.name == "agent")
+    assert agent.working_directory == "."
+    assert agent.build_commands[1][-1] == "requirements.txt"
+    assert agent.run_command[:2] == [".venv/bin/python", "-c"]
+    assert "ThreadingHTTPServer" in agent.run_command[2]
+    assert agent.environment["ALK_CALLBACK_ENTRYPOINT"] == "app.agent:agent_callback"
+    assert agent.environment["PORT"] == "{{PORT_agent}}"
+    assert bundle.capabilities["target_http"].service == "agent"
+    assert any(probe.capability == "target_http" for probe in bundle.readiness)
+    preflight_bundle(
+        tmp_path / "bundle",
+        bundle,
+        parallelism=1,
+        secret_refs={
+            alias: ref.purpose
+            for alias, ref in _job(
+                connector="auto", with_secrets=True
+            ).agent.secret_refs.items()
+        },
+    )
+
+
+def test_callable_contract_rejects_missing_callback(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "agent.py").write_text("print('cli only')\n", encoding="utf-8")
+    authoring = _authoring(tmp_path)
+    _write_callable_contract(authoring)
+
+    with pytest.raises(Exception, match="callback_entrypoint_missing"):
+        author_bundle_v2(
+            source=source,
+            job=_job(connector="auto"),
+            authoring=authoring,
+            output=tmp_path / "bundle",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/harness/test_call_runner.py
+++ b/tests/harness/test_call_runner.py
@@ -1097,3 +1097,27 @@ def test_construction_never_exports_secrets_outside_the_target_provider_map(
     _job_obj, context = _context(tmp_path=tmp_path, secrets=secrets)
     cr.CallRunnerImpl(FakeAdapter(), context, environ=fake_environ)
     assert "UNRELATED_ALIAS" not in fake_environ
+
+
+def test_platform_simulator_credentials_win_without_replacing_target_livekit(
+    tmp_path: Path,
+) -> None:
+    fake_environ = {
+        DEEPGRAM_API_KEY: "platform-deepgram",
+        GEMINI_API_KEY: "platform-gemini",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/run/futureagi/platform-vertex.json",
+        "GOOGLE_CLOUD_PROJECT": "platform-project",
+    }
+    _job_obj, context = _context(tmp_path=tmp_path)
+
+    runner = cr.CallRunnerImpl(FakeAdapter(), context, environ=fake_environ)
+
+    assert fake_environ[LIVEKIT_API_KEY] == "lk-key"
+    assert fake_environ[LIVEKIT_API_SECRET] == "lk-secret"
+    assert fake_environ[DEEPGRAM_API_KEY] == "platform-deepgram"
+    assert fake_environ[GEMINI_API_KEY] == "platform-gemini"
+    assert (
+        fake_environ["GOOGLE_APPLICATION_CREDENTIALS"]
+        == "/run/futureagi/platform-vertex.json"
+    )
+    assert runner._missing_config is None

--- a/tests/harness/test_chat_call_runner.py
+++ b/tests/harness/test_chat_call_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,8 +15,10 @@ from fi.alk.harness.process_runtime import (
     RuntimeEndpoint,
     RuntimeState,
 )
+from fi.alk.harness.run.conversation import Exchange, FINISHED, Transcript
 from fi.alk.harness.world.runtime import Call
-from fi.simulate.agent.wrapper import AgentResponse
+from fi.simulate.agent.wrapper import AgentInput, AgentResponse
+from fi.simulate.agent.wrappers.http import HTTPAgentWrapper
 from fi.simulate.runtime.spec import RuntimeIsolation
 
 
@@ -37,6 +40,56 @@ class _ToolWorld:
             Call(name=call["name"], arguments=call["arguments"], result={"ok": True})
         )
         return SimpleNamespace(content='{"ok": true}')
+
+
+def test_http_wrapper_encodes_tool_history_for_selected_protocol() -> None:
+    calls = [
+        {
+            "id": "tool-1",
+            "type": "function",
+            "function": {
+                "name": "lookup_account",
+                "arguments": '{"account_id":"ACC-2048"}',
+            },
+        }
+    ]
+    request = AgentInput(
+        thread_id="thread-1",
+        messages=[
+            {"role": "user", "content": "Look up my account"},
+            {"role": "assistant", "content": "", "tool_calls": calls},
+        ],
+    )
+
+    callback_payload = HTTPAgentWrapper(
+        endpoint="http://agent/callback", protocol="fi.alk"
+    )._request_payload(request)
+    encoded = callback_payload["messages"][1]["tool_calls"]
+    assert isinstance(encoded, str)
+    assert json.loads(encoded) == calls
+
+    openai_payload = HTTPAgentWrapper(
+        endpoint="http://agent/v1/chat/completions", protocol="openai_chat"
+    )._request_payload(request)
+    assert openai_payload["messages"][1]["tool_calls"] == calls
+
+
+async def _single_exchange(
+    target: Any, scenario: Any, _contract: Any, _bundle_dir: Path
+) -> Transcript:
+    await target.open()
+    try:
+        answer = await target.say(scenario.instruction)
+    finally:
+        await target.close()
+    return Transcript(
+        exchanges=[
+            Exchange("customer", scenario.instruction),
+            Exchange("agent", answer),
+        ],
+        calls=list(target.world.calls),
+        ended=FINISHED,
+    )
 
 
 def _context(tmp_path: Path) -> CallRunnerContext:
@@ -101,6 +154,7 @@ def test_hosted_chat_executes_response_carried_tool_and_uploads_transcript(
 ) -> None:
     tool_world = _ToolWorld()
     monkeypatch.setattr(chat, "_tool_world", lambda *_args: tool_world)
+    monkeypatch.setattr(chat, "_drive_conversation", _single_exchange)
 
     class Wrapper:
         def __init__(self, **_kwargs: Any) -> None:
@@ -170,6 +224,7 @@ def test_hosted_callable_accepts_completed_tool_response_without_second_call(
     )
     tool_world = _ToolWorld()
     monkeypatch.setattr(chat, "_tool_world", lambda *_args: tool_world)
+    monkeypatch.setattr(chat, "_drive_conversation", _single_exchange)
 
     class Wrapper:
         call_count = 0
@@ -228,6 +283,109 @@ def test_hosted_callable_accepts_completed_tool_response_without_second_call(
     assert Wrapper.endpoint == "http://localhost:18080/invoke"
     assert [call.name for call in outcome.calls] == ["lookup_account"]
     assert b"The account is active" in adapter.uploads[0]
+
+
+def test_hosted_chat_continues_when_agent_asks_customer_for_account_id(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    context = _context(tmp_path)
+    scenario_path = context.bundle_dir / "scenarios" / "one" / "scenario.json"
+    scenario = json.loads(scenario_path.read_text(encoding="utf-8"))
+    scenario.update({"name": "one", "max_turns": 4})
+    scenario_path.write_text(json.dumps(scenario), encoding="utf-8")
+    tool_world = _ToolWorld()
+    monkeypatch.setattr(chat, "_tool_world", lambda *_args: tool_world)
+
+    conversation = importlib.import_module("fi.alk.harness.run.conversation")
+
+    class CustomerStage:
+        spent_usd = 0.0
+
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.replies = 0
+
+        async def __aenter__(self) -> "CustomerStage":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def say(self, message: str) -> Any:
+            self.replies += 1
+            if self.replies == 1:
+                return SimpleNamespace(
+                    text="Please show me my portfolio and its yield."
+                )
+            if "account ID" in message:
+                return SimpleNamespace(text="My account ID is CLI-04.")
+            return SimpleNamespace(text="Thanks, that answers my question.\n[DONE]")
+
+    monkeypatch.setattr(conversation, "Stage", CustomerStage)
+
+    class Wrapper:
+        requests: list[Any] = []
+
+        def __init__(self, **_kwargs: Any) -> None:
+            return
+
+        async def call(self, request: Any) -> AgentResponse:
+            type(self).requests.append(request)
+            if len(type(self).requests) == 1:
+                return AgentResponse(content="What is your account ID?")
+            return AgentResponse(
+                content="Your account is active and the yield is 3.1%.",
+                tool_calls=[
+                    {
+                        "id": "tool-1",
+                        "function": {
+                            "name": "lookup_account",
+                            "arguments": '{"account_id":"CLI-04"}',
+                        },
+                    }
+                ],
+                tool_responses=[
+                    {
+                        "role": "tool",
+                        "tool_call_id": "tool-1",
+                        "content": '{"status":"active"}',
+                    }
+                ],
+            )
+
+    monkeypatch.setattr(chat, "HTTPAgentWrapper", Wrapper)
+    adapter = _Adapter()
+    runner = chat.HostedChatCallRunner(adapter, context)
+    runtime = EnvironmentRuntime(
+        runtime_id="runtime-1",
+        world_index=0,
+        bundle_digest="sha256:" + "a" * 64,
+        state=RuntimeState.READY,
+        endpoints={
+            "target_http": RuntimeEndpoint(
+                capability="target_http",
+                protocol="http",
+                address="http://localhost:18080",
+            )
+        },
+    )
+
+    outcome = asyncio.run(
+        runner.run(
+            SimpleNamespace(scenario_key="one", scenario_id="scenario-1"),
+            runtime,
+        )
+    )
+
+    assert len(Wrapper.requests) == 2
+    assert Wrapper.requests[0].new_message["content"] == (
+        "Please show me my portfolio and its yield."
+    )
+    assert Wrapper.requests[1].new_message["content"] == "My account ID is CLI-04."
+    assert [request.turn_index for request in Wrapper.requests] == [0, 1]
+    assert outcome.turns == 5
+    assert [call.name for call in outcome.calls] == ["lookup_account"]
+    assert b"customer: My account ID is CLI-04." in adapter.uploads[0]
+    assert b"agent: Your account is active and the yield is 3.1%." in adapter.uploads[0]
 
 
 def test_tool_world_can_import_customer_tool_from_uploaded_source(

--- a/tests/harness/test_chat_call_runner.py
+++ b/tests/harness/test_chat_call_runner.py
@@ -153,6 +153,83 @@ def test_hosted_chat_executes_response_carried_tool_and_uploads_transcript(
     assert b'"name": "lookup_account"' in adapter.uploads[1]
 
 
+def test_hosted_callable_accepts_completed_tool_response_without_second_call(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    context = _context(tmp_path)
+    contract = json.loads(
+        (context.bundle_dir / "contract.json").read_text(encoding="utf-8")
+    )
+    contract["runtime"]["interface"] = {
+        "kind": "callable",
+        "protocol": "fi.alk",
+        "include_tools": True,
+    }
+    (context.bundle_dir / "contract.json").write_text(
+        json.dumps(contract), encoding="utf-8"
+    )
+    tool_world = _ToolWorld()
+    monkeypatch.setattr(chat, "_tool_world", lambda *_args: tool_world)
+
+    class Wrapper:
+        call_count = 0
+        endpoint = ""
+
+        def __init__(self, **kwargs: Any) -> None:
+            type(self).endpoint = kwargs["endpoint"]
+
+        async def call(self, _request: Any) -> AgentResponse:
+            type(self).call_count += 1
+            return AgentResponse(
+                content="The account is active.",
+                tool_calls=[
+                    {
+                        "id": "tool-1",
+                        "function": {
+                            "name": "lookup_account",
+                            "arguments": '{"account_id":"ACC-2048"}',
+                        },
+                    }
+                ],
+                tool_responses=[
+                    {
+                        "role": "tool",
+                        "tool_call_id": "tool-1",
+                        "content": '{"status":"active"}',
+                    }
+                ],
+            )
+
+    monkeypatch.setattr(chat, "HTTPAgentWrapper", Wrapper)
+    adapter = _Adapter()
+    runner = chat.HostedChatCallRunner(adapter, context)
+    runtime = EnvironmentRuntime(
+        runtime_id="runtime-1",
+        world_index=0,
+        bundle_digest="sha256:" + "a" * 64,
+        state=RuntimeState.READY,
+        endpoints={
+            "target_http": RuntimeEndpoint(
+                capability="target_http",
+                protocol="http",
+                address="http://localhost:18080",
+            )
+        },
+    )
+
+    outcome = asyncio.run(
+        runner.run(
+            SimpleNamespace(scenario_key="one", scenario_id="scenario-1"),
+            runtime,
+        )
+    )
+
+    assert Wrapper.call_count == 1
+    assert Wrapper.endpoint == "http://localhost:18080/invoke"
+    assert [call.name for call in outcome.calls] == ["lookup_account"]
+    assert b"The account is active" in adapter.uploads[0]
+
+
 def test_tool_world_can_import_customer_tool_from_uploaded_source(
     tmp_path: Path, monkeypatch: Any
 ) -> None:

--- a/tests/harness/test_hosted_entrypoint.py
+++ b/tests/harness/test_hosted_entrypoint.py
@@ -847,6 +847,31 @@ def test_peek_secret_values_missing_file_is_empty() -> None:
     assert he.peek_secret_values(Path("/nonexistent/does-not-exist.json")) == ()
 
 
+def test_load_simulator_secret_values_is_allowlisted_and_destructive(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "simulator-secrets.json"
+    path.write_text(
+        json.dumps(
+            {
+                "DEEPGRAM_API_KEY": "platform-deepgram",
+                "GOOGLE_CLOUD_PROJECT": "platform-project",
+                "LIVEKIT_API_SECRET": "must-not-cross-the-control-seam",
+                "UNRELATED": "must-not-load",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    values = he.load_simulator_secret_values(path)
+
+    assert values == {
+        "DEEPGRAM_API_KEY": "platform-deepgram",
+        "GOOGLE_CLOUD_PROJECT": "platform-project",
+    }
+    assert not path.exists()
+
+
 def test_peek_target_provider_secret_values_filters_by_purpose_and_keeps_the_alias() -> (
     None
 ):

--- a/tests/harness/test_process_runtime.py
+++ b/tests/harness/test_process_runtime.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -1417,9 +1418,43 @@ def test_default_process_runner_forwards_user_and_group_to_popen(
     )
     assert captured["user"] == 1234
     assert captured["group"] == 5678
+    assert captured["start_new_session"] is True
     # The log file the harness creates (before the child's privilege drop) is chowned to match —
     # otherwise nothing running as the child's own user could ever open it fresh afterward.
     assert chowned == [(str(tmp_path / "x.log"), 1234, 5678)]
+
+
+def test_popen_process_signals_the_owned_process_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakePopen:
+        pid = 4321
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            raise AssertionError("must signal the complete process group")
+
+        def send_signal(self, _signum: int) -> None:
+            raise AssertionError("must signal the complete process group")
+
+        def kill(self) -> None:
+            raise AssertionError("must signal the complete process group")
+
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(pr.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+    handle = pr.PopenProcess(popen=FakePopen(), log_path=tmp_path / "process.log")
+
+    handle.interrupt()
+    handle.terminate()
+    handle.kill()
+
+    assert signals == [
+        (4321, signal.SIGINT),
+        (4321, signal.SIGTERM),
+        (4321, signal.SIGKILL),
+    ]
 
 
 def test_default_process_runner_does_not_chown_the_log_when_no_user_is_given(


### PR DESCRIPTION
## Summary

- run unpackaged callback agents such as Ava through the hosted HTTP adapter
- restore generic multi-turn chat execution and preserve structured tool evidence
- separate simulator credentials from target-agent credentials
- terminate hosted process groups deterministically during cleanup
- update the hosted snapshot runtime dependencies

## Validation

- full ALK suite: 907 passed, 1 skipped
- Ava: 10 multi-turn hosted chat calls previously validated end to end
- EU LiveKit connectivity independently revalidated from Daytona
