### PR TITLE
feat(harness): expose --guidance on the scenarios CLI for non-interactive extend

### DIFF
--- a/src/fi/alk/harness/cli.py
+++ b/src/fi/alk/harness/cli.py
@@ -1195,6 +1195,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_false",
         help="run unattended instead of staying open for corrections",
     )
+    scenarios.add_argument(
+        "--guidance",
+        action="append",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "a natural-language requirement the saved suite must satisfy; repeatable. "
+            "Non-interactive extend/adjust runs pass these to steer the added scenarios "
+            "while preserving existing validated work"
+        ),
+    )
     scenarios.set_defaults(run=_scenarios, interactive=True)
 
     live = sub.add_parser(


### PR DESCRIPTION
## What
Adds a repeatable `--guidance` flag to the `scenarios` subcommand in `fi.alk.harness.cli`.

## Why
The `scenarios` subcommand already had `--count` and `--once` (non-interactive), and `_scenarios()` already consumes `_guidance(args)` — but no `--guidance` flag was exposed, so `getattr(args, "guidance", None)` was always empty. Hosted "add N scenarios" runs therefore couldn't steer scenario generation through the real CLI; the platform gateway had to hand-write a Python script that imported the private `_scenarios` internal.

With this flag, the platform drives scenario extension through the harness's public CLI contract, consistent with the other stages (`authoring_entrypoint`, `bundle_author_v2`, `hosted_entrypoint`):

```
python -m fi.alk.harness.cli scenarios --name <agent> --out /work/authoring \
  --count N --once --guidance "..." --guidance "..."
```

Reach `--count` total, `--once` (non-interactive), preserving existing validated scenarios, steered by the caller's guidance.

## Change
- `src/fi/alk/harness/cli.py`: `scenarios.add_argument("--guidance", action="append", ...)`

No behavior change to interactive/studio runs (guidance defaults to none). Compiles clean.

Companion platform change (gateway now calls this CLI instead of importing `_scenarios`) lives in the `future-agi` repo.