### PR TITLE
fix(harness): normalize Postgres boolean world values

### DIFF
--- a/Dockerfile.hosted
+++ b/Dockerfile.hosted
@@ -72,7 +72,7 @@ WORKDIR /opt/alk
 # Daytona's direct-image builder can reuse an image when only build-context
 # files change.  Bump this source revision whenever guest code changes so a
 # hosted test cannot silently execute an older installed ALK.
-ARG ALK_HOSTED_SOURCE_REVISION=20260904-connector-auto-r18
+ARG ALK_HOSTED_SOURCE_REVISION=20260904-postgres-boolean-adaptation-r19
 LABEL io.futureagi.alk-source-revision="${ALK_HOSTED_SOURCE_REVISION}"
 COPY pyproject.toml README.md ./
 COPY src ./src

--- a/src/fi/alk/harness/world/stores/postgres.py
+++ b/src/fi/alk/harness/world/stores/postgres.py
@@ -415,10 +415,30 @@ def _adapt(value: Any, data_type: str = "") -> Any:
     """Hand back a value in the form psycopg will write.
 
     A list in a JSON column must be wrapped, while a list in an ARRAY column must remain a list
-    so psycopg emits a native Postgres array.
+    so psycopg emits a native Postgres array. Scenario setup is JSON/Python authored and may
+    therefore represent a boolean as ``0``/``1`` even though PostgreSQL deliberately does not
+    implicitly cast a bound smallint to boolean. Normalize only the finite, unambiguous boolean
+    vocabulary; using ``bool(value)`` here would silently turn values such as ``2`` or
+    ``"disabled"`` into true.
     """
+    normalized_type = data_type.strip().lower()
+    if value is not None and normalized_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
+        if isinstance(value, str):
+            normalized_value = value.strip().lower()
+            if normalized_value in {"true", "t", "1"}:
+                return True
+            if normalized_value in {"false", "f", "0"}:
+                return False
+        raise StoreError(
+            "a PostgreSQL boolean column received "
+            f"{value!r}; expected true/false or the equivalent 1/0"
+        )
     if isinstance(value, dict) or (
-        isinstance(value, list) and data_type in ("json", "jsonb")
+        isinstance(value, list) and normalized_type in ("json", "jsonb")
     ):
         from psycopg.types.json import Jsonb
 

--- a/tests/test_harness_stores.py
+++ b/tests/test_harness_stores.py
@@ -72,6 +72,10 @@ CREATE TABLE orders (
     item        text NOT NULL,
     quantity    int  NOT NULL CHECK (quantity > 0)
 );
+CREATE TABLE boolean_rows (
+    id             text PRIMARY KEY,
+    phone_verified boolean NOT NULL
+);
 """
 
 SEED = """
@@ -107,7 +111,7 @@ def seeded(store):
 @pg
 def test_the_schema_is_the_one_that_was_applied(seeded) -> None:
     """The harness never invents tables. What is here is what the migration created."""
-    assert sorted(seeded.state()) == ["customers", "orders"]
+    assert sorted(seeded.state()) == ["boolean_rows", "customers", "orders"]
 
 
 @pg
@@ -164,6 +168,66 @@ def test_restore_survives_foreign_keys_without_ordering_the_tables(seeded) -> No
 
     seeded.restore(baseline)
     assert seeded.state() == baseline.rows
+
+
+@pg
+def test_boolean_equivalents_work_for_scenario_insert_update_and_restore(
+    seeded,
+) -> None:
+    """Generated setup commonly crosses JSON/SQLite as 0/1 before reaching Postgres.
+
+    All three runtime write paths share ``_adapt``. Prove each one against a real PostgreSQL
+    boolean column so the hosted runner cannot regress to binding a smallint again.
+    """
+    inserted = seeded.add("boolean_rows", {"id": "inserted", "phone_verified": 1})
+    assert inserted["phone_verified"] is True
+
+    assert (
+        seeded.amend(
+            "boolean_rows",
+            "inserted",
+            {"phone_verified": 0},
+            by="id",
+        )
+        == 1
+    )
+    assert seeded.state()["boolean_rows"] == [
+        {"id": "inserted", "phone_verified": False}
+    ]
+
+    seeded.restore(
+        Snapshot(rows={"boolean_rows": [{"id": "restored", "phone_verified": "true"}]})
+    )
+    assert seeded.state()["boolean_rows"] == [
+        {"id": "restored", "phone_verified": True}
+    ]
+
+
+def test_postgres_boolean_adaptation_rejects_ambiguous_values() -> None:
+    from fi.alk.harness.world.stores.postgres import _adapt
+
+    with pytest.raises(StoreError, match="expected true/false"):
+        _adapt(2, "boolean")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        (1, True),
+        (0, False),
+        ("true", True),
+        ("FALSE", False),
+        (" t ", True),
+        (" 0 ", False),
+    ],
+)
+def test_postgres_normalizes_unambiguous_boolean_equivalents(value, expected) -> None:
+    from fi.alk.harness.world.stores.postgres import _adapt
+
+    adapted = _adapt(value, "BOOLEAN")
+    assert adapted is expected
 
 
 @pg


### PR DESCRIPTION
## Summary
- normalize JSON/SQLite boolean equivalents before binding hosted scenario values to PostgreSQL
- cover world.put, world.change, and baseline restore through the shared store adapter
- reject ambiguous boolean values and bump the hosted snapshot cache revision

## Why
Hosted Uber scenarios generated `phone_verified` as `0`/`1`. Psycopg inferred `smallint`, and PostgreSQL rejected writes to boolean columns. This caused scenarios to fail during simulator setup before dialing.

## Tests
- Ruff checks pass
- Harness store tests: 111 passed, 19 skipped
- `git diff --check` passes

The 19 skipped tests require Docker; the local Docker daemon was unavailable during this verification.