### PR TITLE
feat(simulate): Retell outbound originator and sequential leased-room phone runs

### DIFF
--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -30,7 +30,17 @@ jobs:
           report=json.loads(pathlib.Path('smoke-report.json').read_text());
           assert report['status'] == 'ran' and report['report']['results']"
       - name: Install test dependencies
-        run: python -m pip install '.[livekit]' pytest pytest-asyncio
+        # Pin livekit-agents to the version the runner image ships
+        # (Dockerfile.simulation-runner); an unpinned install resolves a
+        # newer release whose usage schema the engine does not target.
+        run: >-
+          python -m pip install '.[livekit]' pytest pytest-asyncio
+          'livekit-agents==1.5.17'
+          'livekit-plugins-cartesia==1.5.17'
+          'livekit-plugins-deepgram==1.5.17'
+          'livekit-plugins-google==1.5.17'
+          'livekit-plugins-openai==1.5.17'
+          'livekit-plugins-silero==1.5.17'
       - name: Run engine + dispatch + acceptance tests
         # Scoped to the suites this PR adds/relies on. The broader tests/ tree has
         # pre-existing failures unrelated to the voice engine (CLI golden-path,

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -41,3 +41,8 @@ jobs:
           tests/runtime/test_livekit_engine.py
           tests/runtime/test_manifest_engine_dispatch.py
           tests/test_acceptance_regressions.py
+          tests/runtime/test_voice_environment.py
+          tests/test_retell_endpoint.py
+          tests/test_retell_transport_validation.py
+          tests/test_call_originator_factory.py
+          tests/test_retell_evidence.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dependencies = [
   "pyyaml>=6.0",
   "requests>=2.32.5,<3",
   "requests-futures>=1.0.0",
+  # ALK pins httpx>=0.24; retell-sdk needs httpx<1,>=0.23 — compatible.
+  # 5.64+: call.list posts to /v3 with the v3 filter vocabulary (D12);
+  # <5.64 used /v2 with a different typed shape.
+  "retell-sdk>=5.64,<6",
   "rich>=13.0.0",
   "rouge-score>=0.1.2",
   "typer>=0.9.0,<1.0.0",

--- a/src/fi/simulate/agent/definition.py
+++ b/src/fi/simulate/agent/definition.py
@@ -4,6 +4,8 @@ from typing import Annotated, Literal, Optional
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, model_validator
 
 
+# Always .fullmatch, never .match: "$" also matches immediately before a
+# trailing newline, so .match alone would let "+14155551234\n" through.
 _E164 = re.compile(r"^\+[1-9]\d{6,14}$")
 
 
@@ -118,9 +120,23 @@ class TelephonyTransport(BaseModel):
         gt=0,
         description="Seconds to wait for an outbound SIP call to be answered.",
     )
-    inbound_call_originator: Literal["vapi"] | None = Field(
+    inbound_call_originator: Literal["vapi", "retell"] | None = Field(
         None,
         description="Provider that originates an inbound SIP call after room readiness.",
+    )
+    originator_agent_id: Optional[str] = Field(
+        None,
+        description=(
+            "Provider agent/assistant ID to run for the originated call "
+            "(sip_inbound with the retell originator only)."
+        ),
+    )
+    originator_from_number: Optional[str] = Field(
+        None,
+        description=(
+            "E.164 number the originator dials from "
+            "(sip_inbound with the retell originator only)."
+        ),
     )
 
     @model_validator(mode="after")
@@ -128,13 +144,18 @@ class TelephonyTransport(BaseModel):
         if self.kind == "sip_outbound":
             if self.inbound_call_originator is not None:
                 raise ValueError("sip_outbound cannot set inbound_call_originator")
+            if (
+                self.originator_agent_id is not None
+                or self.originator_from_number is not None
+            ):
+                raise ValueError("sip_outbound cannot set originator fields")
             if not self.sip_trunk_id or not self.sip_trunk_id.strip():
                 raise ValueError("sip_outbound requires sip_trunk_id")
-            if not self.sip_call_to or not _E164.match(self.sip_call_to):
+            if not self.sip_call_to or not _E164.fullmatch(self.sip_call_to):
                 raise ValueError(
                     "sip_outbound requires E.164 sip_call_to (e.g. +14155551234)"
                 )
-            if not self.sip_number or not _E164.match(self.sip_number):
+            if not self.sip_number or not _E164.fullmatch(self.sip_number):
                 raise ValueError(
                     "sip_outbound requires E.164 sip_number (e.g. +14155551234)"
                 )
@@ -146,6 +167,37 @@ class TelephonyTransport(BaseModel):
                 raise ValueError(
                     "sip_inbound dispatch_rule_name must be non-empty when set"
                 )
+            if (
+                self.originator_agent_id is not None
+                or self.originator_from_number is not None
+            ) and self.inbound_call_originator is None:
+                raise ValueError("originator fields require inbound_call_originator")
+            # C1: the two originator fields are Retell-only; a Vapi originator reads
+            # its config from env and would otherwise silently ignore them.
+            if (
+                self.inbound_call_originator is not None
+                and self.inbound_call_originator != "retell"
+                and (
+                    self.originator_agent_id is not None
+                    or self.originator_from_number is not None
+                )
+            ):
+                raise ValueError(
+                    f"{self.inbound_call_originator}_originator_does_not_take_originator_fields"
+                )
+            # Emptiness is only meaningful once an originator is set (None stays forward-compatible).
+            if (
+                self.inbound_call_originator is not None
+                and self.originator_agent_id is not None
+                and not self.originator_agent_id.strip()
+            ):
+                raise ValueError("originator_agent_id must be non-empty when set")
+            if self.originator_from_number is not None and not _E164.fullmatch(
+                self.originator_from_number
+            ):
+                raise ValueError(
+                    "originator_from_number must be E.164 (e.g. +14155551234)"
+                )
         elif self.kind in {"webrtc", "vapi_websocket", "retell_webcall"}:
             if any(
                 [
@@ -154,6 +206,8 @@ class TelephonyTransport(BaseModel):
                     self.sip_number,
                     self.dispatch_rule_name,
                     self.inbound_call_originator,
+                    self.originator_agent_id,
+                    self.originator_from_number,
                 ]
             ):
                 raise ValueError(f"{self.kind} transport cannot set SIP fields")
@@ -217,7 +271,8 @@ class LiveKitSimulatorRuntime(BaseModel):
         description=(
             "When True, use room_name exactly as provided (no invocation/case "
             "suffix). Required when routing to a pre-existing dispatch rule that "
-            "binds to a fixed room. Only valid for single-persona runs."
+            "binds to a fixed room. A multi-persona run is allowed when cases run "
+            "one at a time (max_concurrency 1; always the case for SIP transports)."
         ),
     )
     api_key_env: str = Field(
@@ -388,13 +443,21 @@ class AgentDefinition(BaseModel):
                     f"{self.target.provider}_target_requires_{expected_transport}"
                 )
         evidence = self.provider_evidence
-        if transport is not None and transport.inbound_call_originator == "vapi":
+        originator = (
+            transport.inbound_call_originator if transport is not None else None
+        )
+        if originator is not None:
+            # Templated on the originator name so Vapi's strings stay byte-identical.
             if transport.kind != "sip_inbound":
-                raise ValueError("vapi_originator_requires_sip_inbound")
-            if evidence is None or evidence.provider != "vapi":
-                raise ValueError("vapi_originator_requires_vapi_evidence")
+                raise ValueError(f"{originator}_originator_requires_sip_inbound")
+            if evidence is None or evidence.provider != originator:
+                raise ValueError(
+                    f"{originator}_originator_requires_{originator}_evidence"
+                )
             if evidence.call_id_source != "originator_response":
-                raise ValueError("vapi_originator_requires_originator_response")
+                raise ValueError(
+                    f"{originator}_originator_requires_originator_response"
+                )
         if evidence is not None and transport is not None:
             if evidence.provider == "retell" and transport.kind == "sip_outbound":
                 raise ValueError(

--- a/src/fi/simulate/endpoints/__init__.py
+++ b/src/fi/simulate/endpoints/__init__.py
@@ -20,8 +20,8 @@ from .base import (
 from .callable import CallableAgentEndpoint
 from .http import HttpAgentEndpoint
 from .livekit import LiveKitAgentEndpoint
-from .retell import RetellAgentEndpoint
-from .vapi import VapiAgentEndpoint
+from .retell import RetellAgentEndpoint, RetellCall, RetellCallOriginator
+from .vapi import VapiAgentEndpoint, VapiCall, VapiCallOriginator
 from .websocket import WebSocketAgentEndpoint
 
 __all__ = [
@@ -36,6 +36,10 @@ __all__ = [
     "ReadinessResult",
     "ReconciliationResult",
     "RetellAgentEndpoint",
+    "RetellCall",
+    "RetellCallOriginator",
     "VapiAgentEndpoint",
+    "VapiCall",
+    "VapiCallOriginator",
     "WebSocketAgentEndpoint",
 ]

--- a/src/fi/simulate/endpoints/originators.py
+++ b/src/fi/simulate/endpoints/originators.py
@@ -1,0 +1,132 @@
+"""Provider-neutral call-origination surface — factory + cleanup helper.
+
+Lives outside ``simulation/engines/livekit.py`` on purpose: that module
+raises ``ImportError`` without the optional ``livekit`` extra (which this
+SDK's dev venv lacks), so nothing inside it can be exercised by tests here;
+this module has no such dependency, so it is fully testable (C3/C6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Protocol
+
+from .retell import RetellCallOriginator
+from .vapi import VapiCallOriginator
+
+
+class CallOriginator(Protocol):
+    """The lifecycle every provider originator satisfies (C2/C3)."""
+
+    async def start(self) -> Any: ...
+
+    async def stop(self, call_id: str) -> None: ...
+
+    async def reconcile_and_stop(
+        self, *, started_after_ms: int, ended_before_ms: int
+    ) -> list[str]: ...
+
+    async def close(self) -> None: ...
+
+
+def build_call_originator(transport: Any) -> CallOriginator:
+    """Construct the originator named by ``transport.inbound_call_originator``.
+
+    This is the one place a provider name is compared to select a class;
+    construction, start, stop and cleanup afterward stay provider-neutral.
+    """
+    name = transport.inbound_call_originator
+    if name == "vapi":
+        return VapiCallOriginator.from_env()
+    if name == "retell":
+        return RetellCallOriginator.from_env(transport)
+    raise ValueError(f"unsupported_inbound_call_originator: {name}")
+
+
+@dataclass(frozen=True)
+class OriginatorFinalizeResult:
+    """What cleanup did, so the engine can adapt it without deciding anything."""
+
+    termination_source: str | None
+    reconciled_call_ids: list[str]
+    cleanup_errors: list[tuple[str, Exception]]
+
+
+async def finalize_originator(
+    originator: CallOriginator,
+    *,
+    provider_call_id: str | None,
+    originator_name: str,
+    case_started_at: datetime,
+    cleanup_timeout: float,
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> OriginatorFinalizeResult:
+    """Best-effort originator cleanup: never raises (C3).
+
+    ``stop()`` ends the call we know about; with no call id in hand (a
+    cancelled ``asyncio.wait_for`` can still leave a live, billed call on
+    the provider's side) ``reconcile_and_stop`` hunts for the orphan instead.
+    ``close()`` always runs, even when the above raised.
+    """
+    termination_source: str | None = None
+    reconciled_call_ids: list[str] = []
+    cleanup_errors: list[tuple[str, Exception]] = []
+    try:
+        if provider_call_id is not None:
+            try:
+                await asyncio.wait_for(
+                    originator.stop(provider_call_id), timeout=cleanup_timeout
+                )
+                termination_source = "sdk_originator_cleanup"
+            except Exception as exc:  # noqa: BLE001 - best-effort cleanup, never raises
+                cleanup_errors.append((f"{originator_name}_call_stop", exc))
+        else:
+            # A naive datetime is read as local time by .timestamp(), silently
+            # widening the blast-radius window; treat it as UTC instead.
+            started = (
+                case_started_at
+                if case_started_at.tzinfo is not None
+                else case_started_at.replace(tzinfo=timezone.utc)
+            )
+            started_after_ms = int(started.timestamp() * 1000)
+            ended_before_ms = int(now().timestamp() * 1000)
+            try:
+                reconciled_call_ids = await asyncio.wait_for(
+                    originator.reconcile_and_stop(
+                        started_after_ms=started_after_ms,
+                        ended_before_ms=ended_before_ms,
+                    ),
+                    timeout=cleanup_timeout,
+                )
+                if reconciled_call_ids:
+                    termination_source = "sdk_originator_cleanup"
+            except TypeError as exc:
+                # A wrong call site (non-int epoch ms) fails loudly and
+                # distinguishably from a swallowed HTTP failure.
+                cleanup_errors.append(
+                    (f"{originator_name}_call_reconcile_bad_arguments", exc)
+                )
+            except Exception as exc:  # noqa: BLE001 - best-effort cleanup, never raises
+                cleanup_errors.append((f"{originator_name}_call_reconcile", exc))
+    finally:
+        try:
+            # Bounded like every other cleanup step, so a slow client can't
+            # stall this case past its cleanup budget.
+            await asyncio.wait_for(originator.close(), cleanup_timeout)
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup, never raises
+            cleanup_errors.append((f"{originator_name}_call_close", exc))
+    return OriginatorFinalizeResult(
+        termination_source=termination_source,
+        reconciled_call_ids=reconciled_call_ids,
+        cleanup_errors=cleanup_errors,
+    )
+
+
+__all__ = [
+    "CallOriginator",
+    "OriginatorFinalizeResult",
+    "build_call_originator",
+    "finalize_originator",
+]

--- a/src/fi/simulate/endpoints/retell.py
+++ b/src/fi/simulate/endpoints/retell.py
@@ -1,4 +1,6 @@
-"""Retell target-agent adapter — capability declaration + Stage 6/8 seam.
+"""Retell target-agent adapter — capability declaration + Stage 6/8 seam,
+plus ``RetellCallOriginator``, the outbound call originator the LiveKit
+engine uses to place and clean up Retell phone calls.
 
 Retell has no PSTN outbound API; ``VapiAgentEndpoint`` supports both
 directions but this adapter refuses ``sip_outbound`` explicitly to
@@ -7,10 +9,31 @@ match the guard in ``AgentDefinition``.
 
 from __future__ import annotations
 
+import logging
+import os
+import re
 import uuid
+import warnings
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Any, Literal
+
+import httpx
+
+try:
+    import retell
+    from retell import AsyncRetell, NoneType
+except ImportError:  # pragma: no cover - exercised via monkeypatch in tests
+    # retell-sdk is an optional dependency: an environment running only
+    # chat/Vapi jobs must still be able to import this module (and the rest
+    # of fi.simulate.endpoints) without it installed. Only
+    # RetellCallOriginator (the class that actually talks to the SDK) fails
+    # loudly, in its own __init__ below — RetellAgentEndpoint/RetellCall
+    # stay httpx-only and never touch these names.
+    retell = None  # type: ignore[assignment]
+    AsyncRetell = None  # type: ignore[assignment,misc]
+    NoneType = type(None)
 
 from fi.simulate.realtime.events import RealtimeEvent
 from fi.simulate.realtime.media import AudioFrame
@@ -24,6 +47,504 @@ from .base import (
     ReadinessResult,
     ReconciliationResult,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _select_call_rows(payload: Any) -> tuple[list[dict[str, Any]], bool]:
+    # Retell's list-calls response shape isn't pinned in docs; accept a bare
+    # list or a dict wrapping one under any of the observed key names. The
+    # bool distinguishes "recognised shape, zero rows" from "a shape this
+    # parser doesn't understand", so callers can tell an empty page apart
+    # from a payload they failed to read.
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)], True
+    if isinstance(payload, dict):
+        for key in ("calls", "results", "items", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)], True
+    # Falls through here for a str (or any other) payload too: the SDK only
+    # raises when a JSON content-type response fails to parse as JSON at
+    # all, so a plain string body — including a proxy/WAF page served
+    # without a JSON content-type — reaches this function as `str` rather
+    # than the ValueError arm in reconcile_and_stop. recognised=False is
+    # still the right signal; it's the caller's job to remember
+    # that "unexpected payload" can mean either an unknown API shape or a
+    # gateway page, not only the former.
+    return [], False
+
+
+def _dump_rows(raw_rows: Any) -> tuple[list[dict[str, Any]], int]:
+    # Convert an iterable of SDK row models to plain dicts so the existing
+    # dict-based row logic in reconcile_and_stop is untouched regardless of
+    # which response shape it came from (a bare-list body or a 5.64
+    # envelope's .items list). Returns (dumped_rows, skipped_count).
+    dumped: list[dict[str, Any]] = []
+    skipped = 0
+    # model_dump emits a pydantic UserWarning
+    # (PydanticSerializationUnexpectedValue) per row with a malformed field
+    # (e.g. a non-int start_timestamp); the value still comes through
+    # unchanged and is then type-checked by the fences in
+    # reconcile_and_stop, so this is noise, not a correctness signal. Scope
+    # the suppression tightly to this call only.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for row in raw_rows:
+            # A non-object array element (e.g. a malformed 200 JSON array
+            # containing a bare string/int/None) has no model_dump — the
+            # SDK's construct_type leaves it as the raw value instead of a
+            # typed row. Skip and count it rather than let AttributeError
+            # escape the swallow below, past every fence, with no log at
+            # all.
+            if not hasattr(row, "model_dump"):
+                skipped += 1
+                continue
+            dumped.append(row.model_dump(mode="json"))
+    return dumped, skipped
+
+
+# A call id reaches an f-string URL untouched; restrict it to a plain token
+# so it can never redirect a request at delete-call or any other path.
+# '.' and ':' are included because they show up in real id formats and
+# cannot create a traversal on their own; requiring an alphanumeric start
+# and forbidding consecutive dots keeps a bare "." or ".." from matching.
+_CALL_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_:-]*(?:\.[A-Za-z0-9_:-]+)*$")
+
+
+def _validate_call_id(call_id: str) -> None:
+    if not isinstance(call_id, str) or not _CALL_ID_PATTERN.fullmatch(call_id):
+        raise ValueError("retell_call_id_invalid")
+
+
+def _strip_or_none(value: Any) -> Any:
+    return value.strip() or None if isinstance(value, str) else value
+
+
+@dataclass(frozen=True)
+class RetellCall:
+    call_id: str
+    status: str | None
+
+
+class RetellCallOriginator:
+    """Create an opt-in Retell call to the LiveKit inbound DID.
+
+    ``reconcile_and_stop`` exists because ``asyncio.wait_for`` cancels our
+    coroutine, not Retell's server-side dial — a slow response can leave a
+    live, billed call with no id in hand. Because ``from_number`` is the
+    customer's production Retell number, the guard is fenced hard: proven
+    filter vocabulary only, a client-side window and exact-destination
+    match, and at most one stop.
+    """
+
+    _base_url = "https://api.retellai.com"
+    _RECONCILE_TIMEOUT = httpx.Timeout(10.0, connect=10.0)
+    _STOPPABLE_STATUSES = {"registered", "ongoing"}
+    _TOLERATED_STOP_STATUSES = {200, 202, 204, 404, 422}
+    _LIST_CALLS_LIMIT = 50
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        agent_id: str,
+        from_number: str,
+        destination: str,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if retell is None:
+            raise RuntimeError(
+                "retell_sdk_missing: RetellCallOriginator needs "
+                "retell-sdk>=5.64,<6 (pip install 'retell-sdk>=5.64,<6')"
+            )
+        self._agent_id = agent_id
+        self._from_number = from_number
+        self._destination = destination
+        # Track ownership of the raw httpx client ourselves rather than via
+        # AsyncRetell.close() — that call closes whatever http_client it was
+        # given, owned or not, which would close a caller-injected client.
+        self._owns_client = client is None
+        self._http = client or httpx.AsyncClient()
+        self._client = AsyncRetell(
+            api_key=api_key,
+            base_url=os.environ.get("RETELL_API_BASE_URL", self._base_url),
+            timeout=httpx.Timeout(30.0, connect=10.0),
+            # Our contract already defines retry/tolerance behaviour (the
+            # tolerated-stop-status set, the reconcile guard); the SDK must
+            # not layer hidden retries on top of it.
+            max_retries=0,
+            http_client=self._http,
+        )
+
+    @classmethod
+    def from_env(cls, transport: Any = None) -> "RetellCallOriginator":
+        # Transport (the job's non-secret config) wins; env vars are the
+        # local-CLI fallback. Secrets and the leased DID are env-only.
+        agent_id = _strip_or_none(getattr(transport, "originator_agent_id", None)) or (
+            os.environ.get("RETELL_AGENT_ID", "").strip() or None
+        )
+        from_number = _strip_or_none(
+            getattr(transport, "originator_from_number", None)
+        ) or (os.environ.get("RETELL_FROM_NUMBER", "").strip() or None)
+        api_key = os.environ.get("RETELL_API_KEY", "").strip() or None
+        destination = os.environ.get("LIVEKIT_INBOUND_DID", "").strip() or None
+        values = {
+            "RETELL_API_KEY": api_key,
+            "RETELL_AGENT_ID": agent_id,
+            "RETELL_FROM_NUMBER": from_number,
+            "LIVEKIT_INBOUND_DID": destination,
+        }
+        missing = [name for name, value in values.items() if not value]
+        if missing:
+            raise ValueError(
+                "retell_originator_config_missing: " + ", ".join(sorted(missing))
+            )
+        return cls(
+            api_key=api_key,
+            agent_id=agent_id,
+            from_number=from_number,
+            destination=destination,
+        )
+
+    async def start(self) -> RetellCall:
+        # Non-2xx raises retell.APIStatusError (a subclass covers each HTTP
+        # status); we let it propagate, same failure surface as before.
+        response = await self._client.call.create_phone_call(
+            from_number=self._from_number,
+            to_number=self._destination,
+            override_agent_id=self._agent_id,
+        )
+        # A 2xx without a JSON content-type is passed through by the SDK as
+        # raw text (or NoneType for a 204), not the typed PhoneCallResponse
+        # model, so `.call_id` would raise AttributeError; getattr keeps the
+        # contracted ValueError the only failure mode here.
+        call_id = getattr(response, "call_id", None)
+        if not isinstance(call_id, str) or not call_id.strip():
+            raise ValueError("retell_call_response_missing_id")
+        status = response.call_status
+        return RetellCall(
+            call_id=call_id,
+            status=str(status) if status is not None else None,
+        )
+
+    async def stop(self, call_id: str, *, timeout: httpx.Timeout | None = None) -> None:
+        # Only stop-call may end a call; delete-call destroys the record and
+        # transcript. 5.8.0 has no typed stop-call method, so this uses the
+        # client's escape hatch to POST the path directly.
+        _validate_call_id(call_id)
+        # Mirror the SDK's own NoneType-cast pattern (call.py's delete():
+        # extra_headers={"Accept": "*/*"}) so this bodyless POST doesn't
+        # advertise a JSON body it never sends, nor demand JSON back from an
+        # endpoint that may answer 204. The escape-hatch post()
+        # takes a RequestOptions dict, not the typed extra_headers kwarg
+        # delete() has, so the header goes directly under "headers" —
+        # probed against the installed SDK: "extra_headers" here is silently
+        # ignored by FinalRequestOptions.construct, "headers" is not.
+        options: dict[str, Any] = {"headers": {"Accept": "*/*"}}
+        if timeout is not None:
+            options["timeout"] = timeout
+        try:
+            await self._client.post(
+                f"/v2/stop-call/{call_id}", cast_to=NoneType, options=options
+            )
+        except retell.APIStatusError as exc:
+            if exc.status_code not in self._TOLERATED_STOP_STATUSES:
+                raise
+
+    async def reconcile_and_stop(
+        self, *, started_after_ms: int, ended_before_ms: int
+    ) -> list[str]:
+        # Argument validation runs before any request so a wrong call site
+        # fails loudly instead of silently returning [].
+        for label, value in (
+            ("started_after_ms", started_after_ms),
+            ("ended_before_ms", ended_before_ms),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(
+                    f"reconcile_and_stop requires int epoch ms for {label}, "
+                    f"got {type(value).__name__}"
+                )
+
+        try:
+            # SDK-typed v3 FilterCriteria (retell/types/call_list_params.py,
+            # confirmed against the installed 5.64.0 wheel ~:605-745):
+            # AsyncCallResource.list posts to /v3/list-calls, and
+            # from_number/to_number are {"type": "string", "op": "eq",
+            # "value": <str>} filters, start_timestamp is a {"type": "range",
+            # "op": "bt", "value": [lower_ms, upper_ms]} filter — not the
+            # list-valued/{lower_threshold, upper_threshold} v2 shape a prior
+            # version of this comment described (PLAN D12, supersedes D10a).
+            # Confirmed on the wire via MockTransport against the installed
+            # SDK. The to_number filter is defense in depth only; every
+            # client-side fence below still applies.
+            response = await self._client.call.list(
+                filter_criteria={
+                    "from_number": {
+                        "type": "string",
+                        "op": "eq",
+                        "value": self._from_number,
+                    },
+                    "to_number": {
+                        "type": "string",
+                        "op": "eq",
+                        "value": self._destination,
+                    },
+                    "start_timestamp": {
+                        "type": "range",
+                        "op": "bt",
+                        "value": [started_after_ms, ended_before_ms],
+                    },
+                },
+                limit=self._LIST_CALLS_LIMIT,
+                timeout=self._RECONCILE_TIMEOUT,
+            )
+            # 5.64+: call.list() returns retell.types.CallListResponse, a
+            # paginated envelope (items/has_more/pagination_key/total), not
+            # a bare list of rows (PLAN D12a). Response handling order:
+            # 1. dict — a test double, or any future/legacy body the SDK
+            #    hands back unparsed. Checked first because dict.items is a
+            #    bound method, not a key list — isinstance(response, dict)
+            #    is the only reliable way to keep that from being confused
+            #    with the envelope's `.items` attribute probed in branch 3.
+            # 2. bare list — a pre-5.64 SDK compatibility path (probed: the
+            #    installed 5.64 SDK constructs one CallListResponse per
+            #    top-level array element via extra="allow" absorption when
+            #    the body itself is a JSON array). Kept for the legacy test
+            #    and any older-SDK deploy.
+            # 3. else (the real 5.64 envelope) — `.items` is a list of
+            #    typed Item pydantic models when the server sent one.
+            #    When it's absent or not a list (an unrecognised envelope,
+            #    or a legacy `{"calls": [...]}` body the SDK folded into an
+            #    extra field instead of `.items` — probed), fall back to
+            #    _select_call_rows on a full model_dump so its legacy
+            #    dict-key fallbacks get one more pass at the envelope, and
+            #    an unrecognised shape still logs a real payload_type
+            #    (e.g. "CallListResponse") instead of "dict" below.
+            skipped = 0
+            if isinstance(response, dict):
+                payload: Any = response
+                rows, recognised = _select_call_rows(payload)
+            elif isinstance(response, list):
+                payload, skipped = _dump_rows(response)
+                rows, recognised = _select_call_rows(payload)
+            else:
+                items = getattr(response, "items", None)
+                if isinstance(items, list):
+                    payload, skipped = _dump_rows(items)
+                    rows, recognised = _select_call_rows(payload)
+                elif hasattr(response, "model_dump"):
+                    rows, recognised = _select_call_rows(
+                        response.model_dump(mode="json")
+                    )
+                    payload = response
+                else:
+                    # Not actually a pydantic model — e.g. a scalar JSON
+                    # body (a bare string or null) the SDK couldn't
+                    # construct CallListResponse from at all, so it comes
+                    # through as the raw str/None value. _select_call_rows
+                    # already falls through such values to ([], False);
+                    # payload stays this raw value so the unexpected_payload
+                    # log below still reports its real type ("str",
+                    # "NoneType"), same as before this round.
+                    payload = response
+                    rows, recognised = _select_call_rows(payload)
+        except (retell.APIError, httpx.HTTPError, ValueError) as exc:
+            # retell.APIError covers both APIStatusError (non-2xx) and
+            # APIConnectionError (transport failure) — the SDK's hierarchy
+            # is not httpx's, so APIConnectionError is NOT an
+            # httpx.HTTPError subclass (the test is the actual net
+            # for a transport failure). httpx.HTTPError is kept only as
+            # insurance for a raw-httpx code path that doesn't exist today —
+            # probed dead against the SDK, harmless to keep. ValueError
+            # covers a non-JSON 2xx body (e.g. a malformed-but-JSON-typed
+            # proxy/WAF page raising json.JSONDecodeError); the
+            # swallow-and-log promise applies to that too, not just
+            # transport-level errors.
+            logger.warning(
+                "retell_call_reconcile",
+                extra={"phase": "list_calls", "error": type(exc).__name__},
+            )
+            return []
+
+        if skipped:
+            # Ignore, informational: a non-object row is not a payload shape
+            # failure (recognised can still be True) and carries no
+            # customer data worth logging — count only, same as the other
+            # dropped-row counters below.
+            logger.warning(
+                "retell_reconcile_unexpected_row", extra={"skipped": skipped}
+            )
+
+        if not recognised:
+            # A JSON body that parsed fine but isn't a shape this parser
+            # understands (e.g. a bare string or null) must not be reported
+            # the same as a genuinely empty page — the two drive opposite
+            # calls on whether the guard is working.
+            logger.warning(
+                "retell_reconcile_unexpected_payload",
+                extra={"payload_type": type(payload).__name__},
+            )
+            return []
+
+        # 5.64's envelope carries an explicit ``has_more``; a full page is the
+        # pre-envelope heuristic. Either means the candidate set may be
+        # truncated; ordering isn't guaranteed so our own call could be off
+        # the page. Read from the envelope object, never from ``payload``.
+        # Checked BEFORE the empty-page return: an empty page the server says
+        # is truncated is page_full (guard may have missed its own call),
+        # never no_candidates (the "page genuinely empty" signal).
+        has_more = bool(getattr(response, "has_more", False))
+        if len(rows) == self._LIST_CALLS_LIMIT or has_more:
+            logger.warning(
+                "retell_reconcile_page_full",
+                extra={"row_count": len(rows), "has_more": has_more},
+            )
+            if not rows:
+                return []
+
+        if not rows:
+            # The likely inert mode: a range filter on start_timestamp can't
+            # match a row that never got one, so a registered call with no
+            # timestamp yet is dropped server-side and never comes back.
+            logger.warning("retell_reconcile_no_candidates")
+            return []
+
+        candidates: list[dict[str, Any]] = []
+        dropped_no_start_timestamp = 0
+        dropped_out_of_window = 0
+        for row in rows:
+            start_ts = row.get("start_timestamp")
+            if not isinstance(start_ts, (int, float)) or isinstance(start_ts, bool):
+                dropped_no_start_timestamp += 1
+                continue
+            # Server-side `bt` filtering is unverified against a live key;
+            # re-check the window here so a widened query can never reach a
+            # call outside it.
+            if not (started_after_ms <= start_ts <= ended_before_ms):
+                dropped_out_of_window += 1
+                continue
+            candidates.append(row)
+        if dropped_no_start_timestamp:
+            logger.warning(
+                "retell_reconcile_no_start_timestamp",
+                extra={"dropped": dropped_no_start_timestamp},
+            )
+        if dropped_out_of_window:
+            logger.warning(
+                "retell_reconcile_out_of_window",
+                extra={"dropped": dropped_out_of_window},
+            )
+        if not candidates:
+            return []
+
+        # The server-side from_number filter (like to_number) is defense in
+        # depth only, not proven — the leased destination DID comes from a
+        # shared pool, so recheck from_number client-side too, the same way
+        # the window is rechecked above, rather than trusting the server
+        # filter to be the only thing scoping this query to our own line.
+        dropped_from_number_mismatch = 0
+        from_number_matches: list[dict[str, Any]] = []
+        for row in candidates:
+            if row.get("from_number") == self._from_number:
+                from_number_matches.append(row)
+            else:
+                dropped_from_number_mismatch += 1
+        if dropped_from_number_mismatch:
+            logger.warning(
+                "retell_reconcile_from_number_mismatch",
+                extra={"dropped": dropped_from_number_mismatch},
+            )
+        candidates = from_number_matches
+        if not candidates:
+            return []
+
+        # A non-string to_number (e.g. a malformed API row shaped as a list
+        # or dict) can never equal our destination string either, so it is
+        # folded into "no usable destination" rather than reaching a set
+        # comprehension, where it would raise instead of just not matching.
+        with_destination = [
+            row for row in candidates if isinstance(row.get("to_number"), str)
+        ]
+        if not with_destination:
+            # Structurally inert against this response shape — not proof no
+            # orphan existed.
+            logger.warning("retell_reconcile_no_destination_field")
+            return []
+
+        # Exact match only: a formatting difference (e.g. E.164 vs local)
+        # must fail closed rather than risk matching a stranger's row.
+        destination_matches = [
+            row for row in with_destination if row.get("to_number") == self._destination
+        ]
+        if not destination_matches:
+            # Never log the observed numbers themselves — they are the
+            # customer's own callees on their production line, not ours.
+            distinct_observed = len({row.get("to_number") for row in with_destination})
+            logger.warning(
+                "retell_reconcile_destination_mismatch",
+                extra={
+                    "destination": self._destination,
+                    "distinct_observed": distinct_observed,
+                    "count": len(with_destination),
+                },
+            )
+            return []
+
+        stoppable = [
+            row
+            for row in destination_matches
+            if str(row.get("call_status") or "").lower() in self._STOPPABLE_STATUSES
+        ]
+        if not stoppable:
+            return []
+
+        # Our own dial is the last event inside the window; stop only the
+        # latest match and leave every other in-window match alone.
+        stoppable.sort(key=lambda row: row["start_timestamp"], reverse=True)
+        target, ambiguous = stoppable[0], stoppable[1:]
+
+        call_id = target.get("call_id")
+        has_id = isinstance(call_id, str)
+        if not has_id or not _CALL_ID_PATTERN.fullmatch(call_id):
+            # Silent [] here would look identical to "the guard worked and
+            # found nothing" — log which of the two shapes it was.
+            logger.warning(
+                "retell_reconcile_target_without_id",
+                extra={"has_id": has_id, "count": len(stoppable)},
+            )
+            return []
+
+        if ambiguous:
+            # The id we stopped is ours by construction (validated above);
+            # the others are the customer's rows and only their count
+            # belongs in our logs.
+            logger.warning(
+                "retell_reconcile_ambiguous",
+                extra={"stopped_call_id": call_id, "left_alone": len(ambiguous)},
+            )
+
+        try:
+            await self.stop(call_id, timeout=self._RECONCILE_TIMEOUT)
+        except (retell.APIError, httpx.HTTPError) as exc:
+            # httpx.HTTPError is kept as insurance only — the SDK's own
+            # errors (APIStatusError, APIConnectionError) are never
+            # httpx.HTTPError subclasses (probed); the transport-error net
+            # is the test on the list_calls phase above.
+            logger.warning(
+                "retell_call_reconcile",
+                extra={"phase": "stop_call", "error": type(exc).__name__},
+            )
+            return []
+
+        return [call_id]
+
+    async def close(self) -> None:
+        # Never AsyncRetell.close() here — it closes self._http regardless
+        # of who created it, which would close a caller-injected client.
+        if self._owns_client:
+            await self._http.aclose()
 
 
 class RetellAgentEndpoint:
@@ -73,7 +594,10 @@ class RetellAgentEndpoint:
             handle_id=f"retell-{uuid.uuid4().hex[:12]}",
             endpoint_name=self.manifest.name,
             created_at=datetime.now(timezone.utc),
-            metadata={"plan_id": getattr(plan, "plan_id", None), "channel": self._channel},
+            metadata={
+                "plan_id": getattr(plan, "plan_id", None),
+                "channel": self._channel,
+            },
         )
 
     async def wait_ready(self, handle: EndpointHandle) -> ReadinessResult:
@@ -104,4 +628,4 @@ class RetellAgentEndpoint:
         return ReconciliationResult(reconciled=True)
 
 
-__all__ = ["RetellAgentEndpoint"]
+__all__ = ["RetellAgentEndpoint", "RetellCall", "RetellCallOriginator"]

--- a/src/fi/simulate/endpoints/retell.py
+++ b/src/fi/simulate/endpoints/retell.py
@@ -397,12 +397,14 @@ class RetellCallOriginator:
         # never no_candidates (the "page genuinely empty" signal).
         has_more = bool(getattr(response, "has_more", False))
         if len(rows) == self._LIST_CALLS_LIMIT or has_more:
+            # Truncated/full page: ordering isn't guaranteed, so our own call
+            # may be off the page. A partial view of the customer's production
+            # account cannot establish ownership — fail closed, stop nothing.
             logger.warning(
                 "retell_reconcile_page_full",
                 extra={"row_count": len(rows), "has_more": has_more},
             )
-            if not rows:
-                return []
+            return []
 
         if not rows:
             # The likely inert mode: a range filter on start_timestamp can't
@@ -500,11 +502,20 @@ class RetellCallOriginator:
         if not stoppable:
             return []
 
-        # Our own dial is the last event inside the window; stop only the
-        # latest match and leave every other in-window match alone.
-        stoppable.sort(key=lambda row: row["start_timestamp"], reverse=True)
-        target, ambiguous = stoppable[0], stoppable[1:]
+        if len(stoppable) > 1:
+            # More than one in-window stoppable row from our line to the leased
+            # DID. Source number + destination + window does not single out our
+            # own call — concurrent calls, a duplicate request, or a prior
+            # timed-out attempt could all sit here — and this is the customer's
+            # production account, so fail closed and stop nothing. Log the count
+            # only, never the third-party ids.
+            logger.warning(
+                "retell_reconcile_ambiguous",
+                extra={"stoppable": len(stoppable)},
+            )
+            return []
 
+        target = stoppable[0]
         call_id = target.get("call_id")
         has_id = isinstance(call_id, str)
         if not has_id or not _CALL_ID_PATTERN.fullmatch(call_id):
@@ -515,15 +526,6 @@ class RetellCallOriginator:
                 extra={"has_id": has_id, "count": len(stoppable)},
             )
             return []
-
-        if ambiguous:
-            # The id we stopped is ours by construction (validated above);
-            # the others are the customer's rows and only their count
-            # belongs in our logs.
-            logger.warning(
-                "retell_reconcile_ambiguous",
-                extra={"stopped_call_id": call_id, "left_alone": len(ambiguous)},
-            )
 
         try:
             await self.stop(call_id, timeout=self._RECONCILE_TIMEOUT)

--- a/src/fi/simulate/endpoints/vapi.py
+++ b/src/fi/simulate/endpoints/vapi.py
@@ -121,6 +121,12 @@ class VapiCallOriginator:
         if response.status_code not in {200, 202, 204, 404}:
             response.raise_for_status()
 
+    async def reconcile_and_stop(
+        self, *, started_after_ms: int, ended_before_ms: int
+    ) -> list[str]:
+        # Vapi's stop() always has a call id in hand; no orphan guard needed.
+        return []
+
     async def close(self) -> None:
         if self._owns_client:
             await self._client.aclose()

--- a/src/fi/simulate/environments/voice.py
+++ b/src/fi/simulate/environments/voice.py
@@ -19,6 +19,9 @@ different role, kept under its existing public name.
 
 from __future__ import annotations
 
+import inspect
+import logging
+
 from fi.simulate.environments.base import EnvironmentManifest
 from fi.simulate.registry import register_environment
 from fi.simulate.runtime.capabilities import EndpointCapabilities
@@ -26,6 +29,42 @@ from fi.simulate.runtime.failures import FailureStage, SimulationFailure
 from fi.simulate.runtime.report import SimulationReport
 from fi.simulate.runtime.run import RunStatus, TestCaseStatus
 from fi.simulate.simulation.models import TestReport
+
+_logger = logging.getLogger(__name__)
+
+# Kwargs VoiceEnvironmentPlugin.run already binds explicitly when it calls
+# run_voice_simulation (see below) — reserved so a same-named key surviving in
+# hosted voice.params cannot collide with them at the call site.
+_PLUGIN_OWNED = frozenset(
+    {
+        "agent_definition",
+        "livekit_runtime",
+        "scenario",
+        "simulator",
+        "simulation_run_id",
+        "on_case_complete",
+        "on_case_start",
+    }
+)
+
+
+def _filter_hosted_voice_params(params: dict, run_voice_simulation) -> dict:
+    """Drop platform-sent keys run_voice_simulation can't bind: it is
+    keyword-only with a closed parameter list, so one stray key would raise
+    TypeError at hydration and kill the whole hosted run. (A **kwargs sink, if
+    one is ever added, accepts everything, so nothing is dropped.)"""
+    parameters = inspect.signature(run_voice_simulation).parameters
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        return dict(params)
+    accepted = {
+        name
+        for name, parameter in parameters.items()
+        if parameter.kind is not inspect.Parameter.VAR_KEYWORD
+    } - _PLUGIN_OWNED
+    dropped = set(params) - accepted
+    if dropped:
+        _logger.warning("hosted_voice_params_ignored", extra={"keys": sorted(dropped)})
+    return {key: value for key, value in params.items() if key in accepted}
 
 
 @register_environment("voice")
@@ -76,7 +115,9 @@ class VoiceEnvironmentPlugin:
             if config.get("simulator")
             else None
         )
-        params = dict(config.get("params") or {})
+        params = _filter_hosted_voice_params(
+            dict(config.get("params") or {}), voice_api.run_voice_simulation
+        )
 
         # When streaming, score the case's goal (if any) BEFORE the case is
         # submitted, so the streamed payload carries ``goal_machine`` metadata

--- a/src/fi/simulate/evidence/providers/retell.py
+++ b/src/fi/simulate/evidence/providers/retell.py
@@ -37,7 +37,10 @@ from .base import (
 )
 
 _RETELL_API_BASE = "https://api.retellai.com"
-_TERMINAL_STATUSES = {"ended", "completed", "error"}
+# "completed" is not a real Retell status; a never-connected dial is terminal.
+_TERMINAL_STATUSES = {"ended", "not_connected", "error"}
+# the two hint sources route to _poll_call; polling_window goes to list-calls
+_HINT_CALL_ID_SOURCES = frozenset({"participant_attribute", "originator_response"})
 _ADAPTER = "retell"
 logger = logging.getLogger(__name__)
 
@@ -91,6 +94,12 @@ class RetellEvidenceSource:
         except httpx.HTTPError as exc:
             return self._unavailable("retell_fetch_failed", error=type(exc).__name__)
         if call_payload is None:
+            if (
+                self._config.call_id_source in _HINT_CALL_ID_SOURCES
+                and self._context.call_id_hint
+            ):
+                # hint path has no matching step; None here means the GET failed
+                return self._unavailable("retell_get_call_failed")
             return self._unavailable("retell_call_not_matched")
         artifacts = await self._download_recording(call_payload)
         summary = self._summarize(call_payload, artifacts)
@@ -104,14 +113,10 @@ class RetellEvidenceSource:
         assert self._context is not None
         context = self._context
         if (
-            self._config.call_id_source
-            in {
-                "participant_attribute",
-                "originator_response",
-            }
+            self._config.call_id_source in _HINT_CALL_ID_SOURCES
             and context.call_id_hint
         ):
-            return await self._get_call(context.call_id_hint)
+            return await self._poll_call(context.call_id_hint)
         window = self._config.polling_window_seconds
         if not window:
             return None
@@ -160,6 +165,24 @@ class RetellEvidenceSource:
                     return await self._get_call(str(call_id))
             if asyncio.get_running_loop().time() >= deadline:
                 return None
+            await asyncio.sleep(self._config.poll_interval_seconds)
+
+    async def _poll_call(self, call_id: str) -> dict[str, Any] | None:
+        # Mirrors vapi._poll_call: Retell fills transcript/recording asynchronously.
+        deadline = (
+            asyncio.get_running_loop().time() + self._config.poll_deadline_seconds
+        )
+        while True:
+            payload = await self._get_call(call_id)
+            if payload is None:
+                return (
+                    None  # 4xx/5xx on get-call: preserve existing return-None behaviour
+                )
+            status = str(payload.get("call_status") or "").lower()
+            if status in _TERMINAL_STATUSES:
+                return payload
+            if asyncio.get_running_loop().time() >= deadline:
+                return payload
             await asyncio.sleep(self._config.poll_interval_seconds)
 
     async def _get_call(self, call_id: str) -> dict[str, Any] | None:

--- a/src/fi/simulate/simulation/engines/livekit.py
+++ b/src/fi/simulate/simulation/engines/livekit.py
@@ -16,7 +16,16 @@ from uuid import uuid4
 
 try:
     from livekit import api, rtc
-    from livekit.agents import Agent, AgentSession, RunContext, function_tool, metrics
+    from livekit.agents import (
+        Agent,
+        AgentSession,
+        AudioConfig,
+        BackgroundAudioPlayer,
+        RunContext,
+        function_tool,
+        metrics,
+    )
+    from livekit.agents.voice.background_audio import BuiltinAudioClip
     from livekit.agents.types import (
         ATTRIBUTE_TRANSCRIPTION_TRACK_ID,
         TOPIC_TRANSCRIPTION,
@@ -63,7 +72,11 @@ from fi.simulate.evidence.providers import (
     RetellEvidenceSource,
     VapiEvidenceSource,
 )
-from fi.simulate.endpoints.vapi import VapiCallOriginator
+from fi.simulate.endpoints.originators import (
+    CallOriginator,
+    build_call_originator,
+    finalize_originator,
+)
 from fi.simulate.simulation.bridge import LiveKitAudioBridge
 from fi.simulate.simulation.livekit_models import LiveKitModels, build_livekit_models
 from fi.simulate.recording.room_recorder import (
@@ -101,6 +114,24 @@ _NO_CONVERSATION_TIMEOUT_SECONDS = 120.0
 _VOICE_MAX_CASE_CONCURRENCY_DEFAULT = 4
 
 
+def _simulator_participant_identity(persona: Persona, test_case_id: str) -> str:
+    """Give repository agents the scenario caller ANI through a standard identity seam.
+
+    LiveKit token metadata is not exposed consistently across every SDK/agent version. The
+    harness therefore uses the identity convention already understood by repository voice
+    agents: ``fagi-simulator-phone-<digits>-...``. A persona without a fixture-derived phone
+    keeps the legacy anonymous identity.
+    """
+    definition = persona.persona if isinstance(persona.persona, dict) else {}
+    metadata = definition.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    digits = re.sub(r"\D", "", str(metadata.get("caller_phone") or ""))
+    suffix = test_case_id[-12:]
+    if 7 <= len(digits) <= 15:
+        return f"fagi-simulator-phone-{digits}-{suffix}"
+    return f"fagi-simulator-{suffix}"
+
+
 def _voice_max_case_concurrency() -> int:
     raw = os.environ.get("ALK_VOICE_MAX_CASE_CONCURRENCY", "").strip()
     if not raw:
@@ -110,6 +141,7 @@ def _voice_max_case_concurrency() -> int:
     except ValueError:
         return _VOICE_MAX_CASE_CONCURRENCY_DEFAULT
     return value if value >= 1 else _VOICE_MAX_CASE_CONCURRENCY_DEFAULT
+
 
 _silero_vad: Any | None = None
 _silero_vad_guard = threading.Lock()
@@ -227,15 +259,25 @@ class _TestRunnerAgent(Agent):
     )
     async def end_call(self, ctx: RunContext) -> str:
         if self._session is None:
+            logger.warning("endCall refused: no session yet")
             return "Continue the conversation before ending the call."
         messages = _session_messages(self._session)
         if len(messages) < self._min_turn_messages or not _has_role_alternation(
             messages
         ):
+            # Whether the caller ever reached for this tool, and why it was turned away, is the
+            # difference between a simulator that will not hang up and one that was not allowed to.
+            logger.warning(
+                "endCall refused: %d messages, floor %d, alternating=%s",
+                len(messages),
+                self._min_turn_messages,
+                _has_role_alternation(messages),
+            )
             return (
                 "Continue the conversation until both speakers have participated "
                 f"and at least {self._min_turn_messages} messages are complete."
             )
+        logger.warning("endCall accepted after %d messages", len(messages))
         # The tool runs inside the same SpeechHandle that carries the model's
         # natural closing sentence. Remember that exact handle before waking
         # the outer runner so it cannot snapshot history in the brief interval
@@ -319,7 +361,85 @@ class _TestRunnerAgent(Agent):
             room=room,
             room_options=RoomOptions(**room_kwargs),
         )
+        await self._maybe_start_background_audio(room, session)
         return session
+
+    async def _maybe_start_background_audio(
+        self, room: "rtc.Room", session: "AgentSession"
+    ) -> None:
+        """Mix caller-side ambient noise under the simulated caller, if the run asked for it.
+
+        Off unless HARNESS_BACKGROUND_NOISE names a source: a LiveKit builtin clip name, or an
+        http(s) URL to an ambient file. Any failure is swallowed, because a call without ambience is
+        preferable to a dropped one.
+        """
+        source = os.environ.get("HARNESS_BACKGROUND_NOISE", "").strip()
+        if not source:
+            return
+
+        def _download() -> str | None:
+            import tempfile
+            import urllib.request
+
+            try:
+                suffix = (
+                    ".mp3"
+                    if ".mp3" in source
+                    else ".ogg"
+                    if ".ogg" in source
+                    else ".wav"
+                )
+                with urllib.request.urlopen(source, timeout=15) as response:
+                    data = response.read()
+                handle = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+                handle.write(data)
+                handle.close()
+                return handle.name
+            except Exception:
+                return None
+
+        try:
+            volume = float(os.environ.get("HARNESS_BACKGROUND_NOISE_VOLUME", "0.3"))
+            if source.startswith(("http://", "https://")):
+                clip_source: Any = await asyncio.to_thread(_download)
+                if not clip_source:
+                    return
+                self._background_noise_file = clip_source
+            else:
+                clip_source = getattr(BuiltinAudioClip, source, None)
+                if clip_source is None:
+                    logger.warning(
+                        "background audio clip %r is not one LiveKit ships", source
+                    )
+                    return
+            player = BackgroundAudioPlayer(
+                ambient_sound=AudioConfig(clip_source, volume=volume)
+            )
+            await player.start(room=room, agent_session=session)
+            self._background_player = player
+        except Exception:
+            logger.warning("background audio not started", exc_info=True)
+
+    async def _stop_background_audio(self) -> None:
+        """Close the ambience player and remove any clip downloaded for it.
+
+        Without this the mixer task, its audio source and the published track outlive the call,
+        and a suite leaks one of each (plus a temp file) per scenario.
+        """
+        player = getattr(self, "_background_player", None)
+        if player is not None:
+            self._background_player = None
+            try:
+                await player.aclose()
+            except Exception:
+                logger.warning("background audio not closed cleanly", exc_info=True)
+        downloaded = getattr(self, "_background_noise_file", None)
+        if downloaded:
+            self._background_noise_file = None
+            try:
+                Path(downloaded).unlink(missing_ok=True)
+            except OSError:
+                logger.warning("background audio clip not removed: %s", downloaded)
 
     def open_conversation(self) -> None:
         if self._session is None:
@@ -361,7 +481,7 @@ class LiveKitEngine(BaseEngine):
         readiness_timeout: float = 30.0,
         cleanup_timeout: float = 30.0,
         conversation_direction: str = "simulator_first",
-        agent_first_silence_timeout_seconds: float = 30.0,
+        agent_first_silence_timeout_seconds: float = 120.0,
         recording_root: str | Path = "recordings",
         recording_case_directory: str | Path | None = None,
         run_id: str | None = None,
@@ -405,39 +525,11 @@ class LiveKitEngine(BaseEngine):
                 num_personas=num_scenarios,
             )
             scenario = Scenario(name="Generated Scenario", dataset=personas)
-        if runtime.room_name_verbatim and len(scenario.dataset) != 1:
-            raise ValueError("room_name_verbatim requires a single-persona scenario")
-        if (
-            runtime.room_mode == "external"
-            and len(scenario.dataset) > 1
-            and not _has_room_template(runtime.room_name)
-        ):
-            raise ValueError(
-                "external_room_template_required: concurrent-safe multi-case runs "
-                "need {run_id}, {test_case_id}, or {index} in room_name"
-            )
         transport = agent_definition.transport or TelephonyTransport()
         profile = _resolve_target_profile(transport.kind)
-        if not profile.uses_external_room and runtime.room_mode != "managed":
-            raise ValueError("managed_transport_requires_managed_room")
-        if (
-            profile.receives_inbound_call
-            and len(scenario.dataset) > 1
-            and not _has_room_template(runtime.room_name)
-        ):
-            raise ValueError(
-                "sip_inbound_room_template_required: multi-case inbound runs "
-                "need {run_id} or {test_case_id} in room_name"
-            )
-        cleanup_timeout = min(cleanup_timeout, _MAX_CLEANUP_TIMEOUT_SECONDS)
-        current_run_id = run_id or new_run_id()
-        if recording_case_directory is not None and len(scenario.dataset) != 1:
-            raise ValueError(
-                "recording_case_directory requires a single-persona scenario"
-            )
-        invocation_id = uuid4().hex[:12]
-        report = TestReport()
-
+        # Computed before the room-name checks below: a serial (concurrency-1)
+        # run is what makes reusing one fixed room across cases safe, so the
+        # verbatim check needs this value, not just the dataset size.
         # Cases run concurrently up to ``max_concurrency`` (bounded by the
         # customer agent's own session capacity). SIP legs stay serial: a run
         # leases a single DID, so overlapping calls would collide. Ask the
@@ -454,6 +546,45 @@ class LiveKitEngine(BaseEngine):
                 ),
             )
         )
+        if (
+            runtime.room_name_verbatim
+            and len(scenario.dataset) != 1
+            and case_concurrency != 1
+        ):
+            raise ValueError(
+                "room_name_verbatim_requires_serial_cases: a fixed room hosts "
+                "one case at a time; run with max_concurrency=1"
+            )
+        if (
+            runtime.room_mode == "external"
+            and len(scenario.dataset) > 1
+            and not _has_room_template(runtime.room_name)
+        ):
+            raise ValueError(
+                "external_room_template_required: concurrent-safe multi-case runs "
+                "need {run_id}, {test_case_id}, or {index} in room_name"
+            )
+        if not profile.uses_external_room and runtime.room_mode != "managed":
+            raise ValueError("managed_transport_requires_managed_room")
+        if (
+            profile.receives_inbound_call
+            and len(scenario.dataset) > 1
+            and not _has_room_template(runtime.room_name)
+            and not runtime.room_name_verbatim
+        ):
+            raise ValueError(
+                "sip_inbound_room_template_required: multi-case inbound runs "
+                "need {run_id} or {test_case_id} in room_name"
+            )
+        cleanup_timeout = min(cleanup_timeout, _MAX_CLEANUP_TIMEOUT_SECONDS)
+        current_run_id = run_id or new_run_id()
+        if recording_case_directory is not None and len(scenario.dataset) != 1:
+            raise ValueError(
+                "recording_case_directory requires a single-persona scenario"
+            )
+        invocation_id = uuid4().hex[:12]
+        report = TestReport()
+
         case_semaphore = asyncio.Semaphore(case_concurrency)
 
         async def _run_case(index: int, persona: Persona) -> TestCaseResult:
@@ -649,7 +780,7 @@ class LiveKitEngine(BaseEngine):
                 "livekit_credentials_missing",
                 f"{runtime.api_key_env} and {runtime.api_secret_env} are required",
             )
-        simulator_identity = f"fagi-simulator-{test_case_id[-12:]}"
+        simulator_identity = _simulator_participant_identity(persona, test_case_id)
         recorder_identity = f"fagi-recorder-{test_case_id[-12:]}"
         room = rtc.Room()
         models: LiveKitModels | None = None
@@ -689,9 +820,11 @@ class LiveKitEngine(BaseEngine):
         outcome: _CaseOutcome | None = None
         sip_dispatch_rule_id: str | None = None
         sip_dispatch_rule_created = False
-        vapi_originator: VapiCallOriginator | None = None
+        call_originator: CallOriginator | None = None
         provider_call_id: str | None = None
         provider_termination_source: str | None = None
+        reconciled_call_ids: list[str] = []
+        caller_verification: str | None = None
         audio_bridge: LiveKitAudioBridge | None = None
         bridge_task: asyncio.Task[None] | None = None
         case_started_at = datetime.now(timezone.utc)
@@ -748,40 +881,86 @@ class LiveKitEngine(BaseEngine):
                     api_secret,
                 )
                 if not profile.places_outbound_call:
-                    try:
-                        await asyncio.wait_for(
-                            api_client.room.create_room(
-                                api.CreateRoomRequest(name=room_name)
-                            ),
-                            timeout=connect_timeout,
-                        )
-                    except asyncio.TimeoutError:
-                        outcome = _failure_outcome(
-                            TestCaseStatus.TIMED_OUT,
-                            FailureStage.PREPARING,
-                            "livekit_room_create_timeout",
-                            "LiveKit room creation exceeded its deadline",
-                            retryable=True,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "LiveKit room creation failed",
-                            exc_info=redacted_exc_info(exc),
-                            extra={
-                                "run_id": run_id,
-                                "test_case_id": test_case_id,
-                                "room_name": room_name,
-                            },
-                        )
-                        outcome = _failure_outcome(
-                            TestCaseStatus.FAILED,
-                            FailureStage.PREPARING,
-                            "livekit_room_create_failed",
-                            "Failed to create the LiveKit room",
-                            details=_safe_provider_error_details(
-                                exc, operation="room_create"
-                            ),
-                        )
+                    # The pool's dispatch rule stays live for the whole run, so a
+                    # stray inbound call can re-create this room at any moment
+                    # between cases — drain it before trusting it as ours.
+                    if runtime.room_name_verbatim:
+                        try:
+                            polls = await asyncio.wait_for(
+                                _ensure_room_absent(api_client, room_name),
+                                timeout=connect_timeout,
+                            )
+                            logger.info(
+                                "leased room drained",
+                                extra={
+                                    "run_id": run_id,
+                                    "test_case_id": test_case_id,
+                                    "room_name": room_name,
+                                    "polls": polls,
+                                },
+                            )
+                        except asyncio.TimeoutError:
+                            outcome = _failure_outcome(
+                                TestCaseStatus.TIMED_OUT,
+                                FailureStage.PREPARING,
+                                "livekit_room_drain_timeout",
+                                "The leased simulator room was still occupied when its drain deadline passed",
+                                retryable=True,
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "leased room drain failed",
+                                exc_info=redacted_exc_info(exc),
+                                extra={
+                                    "run_id": run_id,
+                                    "test_case_id": test_case_id,
+                                    "room_name": room_name,
+                                },
+                            )
+                            outcome = _failure_outcome(
+                                TestCaseStatus.FAILED,
+                                FailureStage.PREPARING,
+                                "livekit_room_drain_failed",
+                                "Could not clear the leased simulator room before the call",
+                                details=_safe_provider_error_details(
+                                    exc, operation="room_drain"
+                                ),
+                            )
+                    if outcome is None:
+                        try:
+                            await asyncio.wait_for(
+                                api_client.room.create_room(
+                                    api.CreateRoomRequest(name=room_name)
+                                ),
+                                timeout=connect_timeout,
+                            )
+                        except asyncio.TimeoutError:
+                            outcome = _failure_outcome(
+                                TestCaseStatus.TIMED_OUT,
+                                FailureStage.PREPARING,
+                                "livekit_room_create_timeout",
+                                "LiveKit room creation exceeded its deadline",
+                                retryable=True,
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "LiveKit room creation failed",
+                                exc_info=redacted_exc_info(exc),
+                                extra={
+                                    "run_id": run_id,
+                                    "test_case_id": test_case_id,
+                                    "room_name": room_name,
+                                },
+                            )
+                            outcome = _failure_outcome(
+                                TestCaseStatus.FAILED,
+                                FailureStage.PREPARING,
+                                "livekit_room_create_failed",
+                                "Failed to create the LiveKit room",
+                                details=_safe_provider_error_details(
+                                    exc, operation="room_create"
+                                ),
+                            )
                 if outcome is None and profile.uses_external_room:
                     # Defer the target dispatch until AFTER the early buffer
                     # handler is registered and the session is live (both
@@ -832,12 +1011,22 @@ class LiveKitEngine(BaseEngine):
                         )
             if outcome is not None:
                 return outcome
-            token = (
+            # The target resolves who is calling from participant attributes or metadata.
+            # Without the persona's number every scenario looks like the same demo rider and
+            # the agent looks up the wrong account, which reads as an agent bug.
+            caller_phone = str(
+                (persona.persona.get("metadata") or {}).get("caller_phone") or ""
+            ).strip()
+            builder = (
                 AccessToken(api_key, api_secret)
                 .with_identity(simulator_identity)
                 .with_grants(VideoGrants(room_join=True, room=room_name))
-                .to_jwt()
             )
+            if caller_phone:
+                builder = builder.with_attributes(
+                    {"harness.callerPhone": caller_phone}
+                ).with_metadata(json.dumps({"caller_phone": caller_phone}))
+            token = builder.to_jwt()
             await asyncio.wait_for(
                 room.connect(str(runtime.url), token),
                 timeout=connect_timeout,
@@ -868,13 +1057,34 @@ class LiveKitEngine(BaseEngine):
             customer_agent, models = await self._create_customer_agent(
                 persona,
                 simulator,
-                call_type=(
-                    "inbound"
-                    if conversation_direction == "simulator_first"
-                    else "outbound"
-                ),
-                agent_name=agent_definition.name,
+                # Who dialled and who speaks first are separate axes. The caller always places
+                # the call; conversation_direction only decides who opens once connected.
+                call_type="inbound",
+                # `name` is an identity for dispatch, not a label for the caller to hear.
+                agent_name=agent_definition.description,
                 min_turn_messages=min_turn_messages,
+            )
+            setup = getattr(self, "_last_simulator_setup", {}) or {}
+            _record_simulator_setup(
+                case_directory,
+                persona=persona,
+                instructions=setup.get("instructions", ""),
+                llm_config=setup.get("llm_config"),
+                stt_config=setup.get("stt_config"),
+                tts_config=setup.get("tts_config"),
+                extra={
+                    "room_name": room_name,
+                    "agent_name": agent_definition.name,
+                    "test_case_id": test_case_id,
+                    "run_id": run_id,
+                    "conversation_direction": conversation_direction,
+                    "allow_interruptions": setup.get("allow_interruptions"),
+                    "min_endpointing_delay": setup.get("min_endpointing_delay"),
+                    "max_endpointing_delay": setup.get("max_endpointing_delay"),
+                    "use_tts_aligned_transcript": setup.get(
+                        "use_tts_aligned_transcript"
+                    ),
+                },
             )
             sip_participant_identity: str | None = None
             bridge_identity: str | None = None
@@ -1074,25 +1284,50 @@ class LiveKitEngine(BaseEngine):
                         "sip_dispatch_rule_created": sip_dispatch_rule_created,
                     },
                 )
-            if transport.inbound_call_originator == "vapi":
-                try:
-                    vapi_originator = VapiCallOriginator.from_env()
-                    vapi_call = await asyncio.wait_for(
-                        vapi_originator.start(), timeout=connect_timeout
+            if runtime.room_name_verbatim and profile.receives_inbound_call:
+                unexpected = _unexpected_participants(
+                    room,
+                    simulator_identity=simulator_identity,
+                    recorder_identity=recorder_identity,
+                )
+                if unexpected:
+                    logger.warning(
+                        "leased room occupied before dial",
+                        extra={
+                            "run_id": run_id,
+                            "test_case_id": test_case_id,
+                            "room_name": room_name,
+                            "unexpected_participants": len(unexpected),
+                        },
                     )
-                    provider_call_id = vapi_call.call_id
+                    outcome = _failure_outcome(
+                        TestCaseStatus.FAILED,
+                        FailureStage.PREPARING,
+                        "livekit_room_occupied",
+                        "Another participant was already in the leased simulator room before the call was placed",
+                        retryable=True,
+                    )
+                    return outcome
+            if transport.inbound_call_originator is not None:
+                name = transport.inbound_call_originator
+                try:
+                    call_originator = build_call_originator(transport)
+                    originated_call = await asyncio.wait_for(
+                        call_originator.start(), timeout=connect_timeout
+                    )
+                    provider_call_id = originated_call.call_id
                 except asyncio.TimeoutError:
                     outcome = _failure_outcome(
                         TestCaseStatus.TIMED_OUT,
                         FailureStage.PREPARING,
-                        "vapi_call_start_timeout",
-                        "Vapi call creation exceeded its deadline",
+                        f"{name}_call_start_timeout",
+                        f"{name.capitalize()} call creation exceeded its deadline",
                         retryable=True,
                     )
                     return outcome
                 except Exception as exc:
                     logger.warning(
-                        "Vapi call creation failed",
+                        f"{name.capitalize()} call creation failed",
                         exc_info=redacted_exc_info(exc),
                         extra={
                             "run_id": run_id,
@@ -1102,10 +1337,10 @@ class LiveKitEngine(BaseEngine):
                     outcome = _failure_outcome(
                         TestCaseStatus.FAILED,
                         FailureStage.PREPARING,
-                        "vapi_call_start_failed",
-                        "Failed to start the Vapi call",
+                        f"{name}_call_start_failed",
+                        f"Failed to start the {name.capitalize()} call",
                         details=_safe_provider_error_details(
-                            exc, operation="vapi_call_start"
+                            exc, operation=f"{name}_call_start"
                         ),
                     )
                     return outcome
@@ -1115,6 +1350,42 @@ class LiveKitEngine(BaseEngine):
                 target_identity=effective_target_identity,
                 timeout=effective_readiness_timeout,
             )
+            if (
+                runtime.room_name_verbatim
+                and profile.receives_inbound_call
+                and transport.originator_from_number
+            ):
+                verdict = _caller_matches(
+                    target.attributes, transport.originator_from_number
+                )
+                if verdict is False:
+                    logger.warning(
+                        "leased room wrong caller",
+                        extra={
+                            "run_id": run_id,
+                            "test_case_id": test_case_id,
+                            "expected_digits": len(
+                                _number_digits(transport.originator_from_number)
+                            ),
+                            "observed_digits": len(
+                                _number_digits(
+                                    target.attributes.get(
+                                        _SIP_REMOTE_NUMBER_ATTRIBUTE, ""
+                                    )
+                                )
+                            ),
+                        },
+                    )
+                    caller_verification = "mismatch"
+                    raise _LeasedRoomCallerMismatch()
+                elif verdict is None:
+                    logger.warning(
+                        "leased room caller unverified",
+                        extra={"run_id": run_id, "test_case_id": test_case_id},
+                    )
+                    caller_verification = "unverified"
+                else:
+                    caller_verification = "matched"
             logger.info(
                 "livekit_target_joined identity=%s sid=%s track=%s run=%s case=%s",
                 target.identity,
@@ -1286,6 +1557,17 @@ class LiveKitEngine(BaseEngine):
                 message,
                 retryable=True,
             )
+        except _LeasedRoomCallerMismatch:
+            # Unlike the pre-dial failures above, this path has a billed call and
+            # a joined target; the recordings, provider evidence and metadata
+            # update below all run after the try, so this must not return early.
+            outcome = _failure_outcome(
+                TestCaseStatus.FAILED,
+                FailureStage.READINESS,
+                "livekit_room_wrong_caller",
+                "The participant that answered is not calling from the customer's configured number",
+                retryable=True,
+            )
         except Exception as exc:
             logger.error(
                 "LiveKit test case failed",
@@ -1304,6 +1586,13 @@ class LiveKitEngine(BaseEngine):
                 details={"exception_type": type(exc).__name__},
             )
         finally:
+            # The ambience belongs to the caller agent, not the engine. Guarded because teardown
+            # must never be the reason a case fails.
+            if customer_agent is not None:
+                try:
+                    await customer_agent._stop_background_audio()
+                except Exception:
+                    logger.warning("background audio not closed cleanly", exc_info=True)
             if target_transcription_handler_registered:
                 room.unregister_text_stream_handler(TOPIC_TRANSCRIPTION)
             pending_target_transcriptions.clear()
@@ -1385,20 +1674,44 @@ class LiveKitEngine(BaseEngine):
                         run_id,
                         test_case_id,
                     )
-            if vapi_originator is not None:
+            if call_originator is not None:
+                # Guarded like every other cleanup step below: a future escape
+                # from the helper (today it never raises) must not skip the
+                # dispatch-rule/room/api-client teardown that follows.
                 try:
-                    if provider_call_id is not None:
-                        await asyncio.wait_for(
-                            vapi_originator.stop(provider_call_id),
-                            timeout=cleanup_timeout,
+                    finalize_result = await finalize_originator(
+                        call_originator,
+                        provider_call_id=provider_call_id,
+                        originator_name=transport.inbound_call_originator,
+                        case_started_at=case_started_at,
+                        cleanup_timeout=cleanup_timeout,
+                    )
+                    for operation, exc in finalize_result.cleanup_errors:
+                        _record_cleanup_error(
+                            cleanup_errors, exc, operation, run_id, test_case_id
                         )
-                        provider_termination_source = "sdk_originator_cleanup"
-                    await vapi_originator.close()
+                    if finalize_result.termination_source:
+                        provider_termination_source = finalize_result.termination_source
+                    reconciled_call_ids = finalize_result.reconciled_call_ids
+                    if provider_call_id is None and reconciled_call_ids:
+                        # We stopped a billed call we believe is ours, so
+                        # evidence fetches its record instead of reporting
+                        # "not matched" after searching nothing.
+                        provider_call_id = reconciled_call_ids[0]
+                    # Written here too (not only in the metadata.update below)
+                    # because a start-failure path returns from inside the try,
+                    # bypassing that block entirely.
+                    if outcome is not None:
+                        outcome.metadata["reconciled_call_ids"] = reconciled_call_ids
+                        if finalize_result.termination_source:
+                            outcome.metadata["provider_termination_source"] = (
+                                finalize_result.termination_source
+                            )
                 except Exception as exc:
                     _record_cleanup_error(
                         cleanup_errors,
                         exc,
-                        "vapi_call_stop",
+                        f"{transport.inbound_call_originator}_call_finalize",
                         run_id,
                         test_case_id,
                     )
@@ -1449,6 +1762,14 @@ class LiveKitEngine(BaseEngine):
                         run_id,
                         test_case_id,
                     )
+            # Written here too (not only in the metadata.update below) because a
+            # pre-dial return (e.g. the occupancy check) exits from inside the
+            # try, bypassing that block entirely.
+            if outcome is not None and outcome.metadata.get("cleanup_status") is None:
+                outcome.metadata["cleanup_status"] = (
+                    "failed" if cleanup_errors else "completed"
+                )
+                outcome.metadata["cleanup_errors"] = cleanup_errors
         if outcome is None:
             outcome = _failure_outcome(
                 TestCaseStatus.FAILED,
@@ -1514,6 +1835,8 @@ class LiveKitEngine(BaseEngine):
                     provider_target.provider if provider_target is not None else None
                 ),
                 "provider_call_id": provider_call_id,
+                "reconciled_call_ids": reconciled_call_ids,
+                "caller_verification": caller_verification,
                 "vapi_call_id": (
                     provider_call_id
                     if profile.evidence_provider == "vapi"
@@ -1523,6 +1846,7 @@ class LiveKitEngine(BaseEngine):
                 "retell_call_id": (
                     provider_call_id
                     if profile.evidence_provider == "retell"
+                    or transport.inbound_call_originator == "retell"
                     else None
                 ),
                 "simulator_model_usage": (
@@ -1611,6 +1935,16 @@ class LiveKitEngine(BaseEngine):
             tts_config=tts_config,
         )
         vad = await asyncio.to_thread(_load_silero_vad_sync)
+        self._last_simulator_setup = {
+            "instructions": instructions,
+            "llm_config": llm_config,
+            "stt_config": stt_config,
+            "tts_config": tts_config,
+            "allow_interruptions": allow_interruptions,
+            "min_endpointing_delay": min_endpointing_delay,
+            "max_endpointing_delay": max_endpointing_delay,
+            "use_tts_aligned_transcript": use_aligned_transcript,
+        }
         agent = _TestRunnerAgent(
             persona=persona,
             min_turn_messages=min_turn_messages,
@@ -1730,7 +2064,7 @@ def _find_target_audio(
     excluded_identities: set[str],
     target_identity: str | None,
 ) -> _TargetParticipant | None:
-    candidates: list[tuple[int, _TargetParticipant]] = []
+    candidates: list[tuple[int, int, _TargetParticipant]] = []
     agent_kind = getattr(
         rtc.ParticipantKind,
         "PARTICIPANT_KIND_AGENT",
@@ -1746,10 +2080,22 @@ def _find_target_audio(
         for publication in participant.track_publications.values():
             if getattr(publication, "kind", None) != rtc.TrackKind.KIND_AUDIO:
                 continue
+            # Agents may publish ambient music/noise alongside their synthesized speech. The
+            # first LiveKit publication is not necessarily the conversational track (the
+            # official drive-thru example publishes ``background_audio``). Prefer ordinary
+            # speech/microphone tracks so STT, transcription filtering, and recording all bind
+            # to the same semantic stream.
+            track_name = str(getattr(publication, "name", "") or "").lower()
+            background = any(
+                marker in track_name
+                for marker in ("background", "ambient", "music", "sound_effect")
+            )
+            track_priority = 1 if background else 0
             attrs = dict(getattr(participant, "attributes", {}) or {})
             candidates.append(
                 (
                     priority,
+                    track_priority,
                     _TargetParticipant(
                         identity=identity,
                         sid=str(participant.sid),
@@ -1762,7 +2108,15 @@ def _find_target_audio(
             )
     if not candidates:
         return None
-    return sorted(candidates, key=lambda item: (item[0], item[1].identity))[0][1]
+    return sorted(
+        candidates,
+        key=lambda item: (
+            item[0],
+            item[1],
+            item[2].identity,
+            item[2].audio_track_sid,
+        ),
+    )[0][2]
 
 
 # A run ends naturally when the simulator calls ``endCall``; this is only the
@@ -1820,6 +2174,7 @@ async def _wait_for_conversation_end(
         "conversation_settled": asyncio.create_task(
             _wait_for_conversation_silence(session)
         ),
+        "closing_loop": asyncio.create_task(_wait_for_closing_loop(session)),
         "no_conversation": asyncio.create_task(
             _wait_for_conversation_never_started(
                 session,
@@ -1878,6 +2233,9 @@ async def _wait_for_conversation_end(
             "target_disconnected",
             "room_disconnected",
             "no_conversation",
+            # A farewell loop is a finished conversation, so it outranks the silence backstop
+            # that would otherwise report the same call as a stall.
+            "closing_loop",
             "conversation_silence_timeout",
             "conversation_settled",
             "provider_disconnected",
@@ -1895,6 +2253,63 @@ async def _wait_for_conversation_end(
             on_participant_disconnected,
         )
         _remove_room_listener(room, "disconnected", on_room_disconnected)
+
+
+_CLOSING_PHRASES = (
+    "goodbye",
+    "bye",
+    "take care",
+    "have a great day",
+    "have a good day",
+    "have a wonderful day",
+    "you too",
+)
+
+_CLOSING_EXCHANGE_LIMIT = 4
+
+
+def _is_closing_only(text: str) -> bool:
+    """Whether a turn is nothing but a farewell.
+
+    Deliberately narrow: a turn that closes AND carries anything else (a question, a fact, a
+    correction) is still conversation, and ending on it would cut a live call short.
+    """
+    stripped = "".join(
+        character.lower() if character.isalnum() or character.isspace() else " "
+        for character in (text or "")
+    ).split()
+    if not stripped or len(stripped) > 6:
+        return False
+    joined = " ".join(stripped)
+    return any(phrase in joined for phrase in _CLOSING_PHRASES)
+
+
+async def _wait_for_closing_loop(
+    session: AgentSession,
+    *,
+    limit: int = _CLOSING_EXCHANGE_LIMIT,
+) -> None:
+    """Finish once both sides are only trading farewells.
+
+    A simulator that does not reach for ``endCall`` leaves the target answering goodbye with
+    goodbye until the deadline. One such call ran seventy-six turns, held its worker past the
+    world pool's patience and cost the rest of that job its worlds, so this ends the call on the
+    evidence already in the transcript rather than waiting for a timeout that arrives too late.
+    """
+    while True:
+        messages = _session_messages(session)
+        tail = [
+            message for message in messages if (message.get("content") or "").strip()
+        ][-limit:]
+        if len(tail) == limit and all(
+            _is_closing_only(str(message.get("content") or "")) for message in tail
+        ):
+            logger.info(
+                "closing loop: last %d turns were farewells only, ending the call",
+                limit,
+            )
+            return
+        await asyncio.sleep(1.0)
 
 
 async def _wait_for_conversation_silence(
@@ -2042,14 +2457,11 @@ def _session_messages(session: AgentSession) -> list[dict[str, Any]]:
                     or current["stopped_speaking_at"]
                 )
             elif previous.get("interrupted") or interrupted:
-                previous["content"] = (
-                    f"{previous_text} {current['content']}".strip()
-                )
+                previous["content"] = f"{previous_text} {current['content']}".strip()
                 previous["interrupted"] = interrupted
-                previous["stopped_speaking_at"] = (
-                    current["stopped_speaking_at"]
-                    or previous.get("stopped_speaking_at")
-                )
+                previous["stopped_speaking_at"] = current[
+                    "stopped_speaking_at"
+                ] or previous.get("stopped_speaking_at")
             else:
                 messages.append(current)
             continue
@@ -2202,6 +2614,30 @@ def _merge_captured_target_turns(
     return merged
 
 
+def _caller_never_spoke(messages: list[dict[str, Any]]) -> bool:
+    """Whether the simulated caller's turns exist as text with no audio behind them.
+
+    Speech synthesis that fails still leaves the caller's line in the transcript, so a mute
+    simulator and a silent agent produce the same stall unless the missing audio is read directly.
+    """
+
+    def timed(message: dict[str, Any]) -> bool:
+        return isinstance(message.get("started_speaking_at"), (int, float))
+
+    spoken = [
+        message
+        for message in messages
+        if message.get("role") == "user" and (message.get("content") or "").strip()
+    ]
+    if not spoken or any(timed(message) for message in spoken):
+        return False
+    # Only the agent's turns carrying timing makes the caller's missing timing evidence of
+    # silence rather than a transcript that simply does not record when anyone spoke.
+    return any(
+        timed(message) for message in messages if message.get("role") == "assistant"
+    )
+
+
 def _has_role_alternation(messages: list[dict[str, Any]]) -> bool:
     roles = {msg.get("role") for msg in messages if msg.get("content")}
     return "user" in roles and "assistant" in roles
@@ -2216,6 +2652,28 @@ def _conversation_outcome(
     transcript = "\n".join(
         f"{message['role']}: {message['content']}" for message in messages
     )
+    if (
+        stop_reason == "conversation_silence_timeout"
+        and len(messages) >= min_turn_messages
+        and _has_role_alternation(messages)
+        and _has_natural_terminal_exchange(messages)
+    ):
+        # Agent-first calls use a short silence watchdog because the tested
+        # agent owns the opening turn.  A simulator can occasionally omit its
+        # endCall tool even after both sides have clearly closed the call.  Do
+        # not turn a fully recorded farewell/transfer into an infrastructure
+        # failure merely because the now-idle room remained open.  Evaluation
+        # still decides whether the agent actually completed the requested
+        # business action.
+        return _CaseOutcome(
+            status=TestCaseStatus.COMPLETED,
+            transcript=transcript,
+            messages=messages,
+            metadata={
+                "stop_reason": stop_reason,
+                "terminal_exchange_recovered": True,
+            },
+        )
     if stop_reason == "timeout":
         return _failure_outcome(
             TestCaseStatus.TIMED_OUT,
@@ -2225,6 +2683,20 @@ def _conversation_outcome(
             transcript=transcript,
             messages=messages,
             retryable=True,
+        )
+    if stop_reason == "conversation_silence_timeout" and _caller_never_spoke(messages):
+        # The target sat in real silence because nothing was ever spoken at it. Retrying cannot
+        # put a voice back on the line, so fail fast and name the synthesis rather than spending
+        # the attempt budget reporting the agent as stalled.
+        return _failure_outcome(
+            TestCaseStatus.FAILED,
+            FailureStage.RUNNING,
+            "simulator_tts_silent",
+            "Simulated caller produced transcript text but no audio",
+            transcript=transcript,
+            messages=messages,
+            retryable=False,
+            details={"stop_reason": stop_reason, "turn_count": str(len(messages))},
         )
     if stop_reason in {
         "conversation_silence_timeout",
@@ -2241,12 +2713,10 @@ def _conversation_outcome(
                 "Conversation session closed before a natural end condition"
             ),
             "no_conversation": (
-                "No conversation turns were committed before the inactivity "
-                "deadline"
+                "No conversation turns were committed before the inactivity deadline"
             ),
             "monitor_failed": (
-                "Conversation end monitoring failed before a natural end "
-                "condition"
+                "Conversation end monitoring failed before a natural end condition"
             ),
         }[stop_reason]
         return _failure_outcome(
@@ -2287,6 +2757,53 @@ def _conversation_outcome(
     )
 
 
+def _has_natural_terminal_exchange(messages: list[dict[str, str]]) -> bool:
+    """Recognize only explicit terminal language near the end of a call.
+
+    This deliberately avoids broad sentiment or short-answer heuristics.  A
+    normal unanswered question must remain a silence failure.  The two safe
+    cases are an explicit farewell, or a transfer handoff followed by the
+    caller's acknowledgement.
+    """
+    tail = [
+        (
+            str(message.get("role") or "").lower(),
+            str(message.get("content") or "").strip().lower(),
+        )
+        for message in messages[-4:]
+        if str(message.get("content") or "").strip()
+    ]
+    if not tail:
+        return False
+    farewell_markers = (
+        "goodbye",
+        "bye",
+        "take care",
+        "have a great day",
+        "have a good day",
+        "have a nice day",
+    )
+    if any(marker in text for _role, text in tail for marker in farewell_markers):
+        return True
+
+    for index, (role, text) in enumerate(tail[:-1]):
+        if role != "assistant" or "transfer" not in text:
+            continue
+        if not any(marker in text for marker in ("now", "connect", "please wait")):
+            continue
+        next_role, acknowledgement = tail[index + 1]
+        if next_role == "user" and acknowledgement.rstrip(".! ") in {
+            "ok",
+            "okay",
+            "alright",
+            "please do",
+            "thank you",
+            "thanks",
+        }:
+            return True
+    return False
+
+
 def _failure_outcome(
     status: TestCaseStatus,
     stage: FailureStage,
@@ -2313,6 +2830,58 @@ def _failure_outcome(
     )
 
 
+def _record_simulator_setup(
+    case_directory: Path,
+    *,
+    persona: Persona,
+    instructions: str,
+    llm_config: Any,
+    stt_config: Any,
+    tts_config: Any,
+    turn_handling: Any = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Write the exact prompt and voice settings this call is about to use.
+
+    Reconstructing either one afterwards from a transcript is guesswork, and the simulator's
+    prompt is what decides how the caller behaves. Written before the call connects so it
+    survives a run that dies mid-conversation.
+    """
+
+    def settings(config: Any) -> Any:
+        if config is None:
+            return None
+        for method in ("model_dump", "dict"):
+            dump = getattr(config, method, None)
+            if callable(dump):
+                try:
+                    return dump()
+                except Exception:  # noqa: BLE001 - never fail a call over logging
+                    pass
+        return str(config)
+
+    try:
+        case_directory.mkdir(parents=True, exist_ok=True)
+        (case_directory / "simulator-prompt.txt").write_text(
+            instructions or "", encoding="utf-8"
+        )
+        payload = {
+            "persona": settings(persona),
+            "simulator_system_prompt": instructions or "",
+            "llm": settings(llm_config),
+            "stt": settings(stt_config),
+            "tts": settings(tts_config),
+            "turn_handling": settings(turn_handling),
+        }
+        payload.update(extra or {})
+        (case_directory / "simulator-setup.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+    except Exception as error:  # noqa: BLE001 - logging must never break a run
+        logger.warning("could not record simulator setup: %s", error)
+
+
 def _attach_recordings(
     outcome: _CaseOutcome,
     recorder: RoomRecorder,
@@ -2332,6 +2901,30 @@ def _attach_recordings(
         if target_identity is not None
         else []
     )
+    # ``audio_track_sid`` identifies the track used to establish target
+    # readiness, but it is not necessarily the track that remains published for
+    # the conversation.  Agents using ``BackgroundAudioPlayer`` publish more
+    # than one audio track and can replace the initially selected publication.
+    # Recording is evidence of the whole participant, so fall back to all of the
+    # target participant's tracks instead of silently producing no artifact.
+    if target_identity is not None and not target_paths:
+        target_paths = recorder.paths_for_participant(target_identity)
+
+    # The simulator normally publishes with ``simulator_identity``.  Retain a
+    # conservative fallback for SDKs that expose the local publication under a
+    # different participant identity: only use it when there is exactly one
+    # non-target publishing participant, so another caller can never be folded
+    # into the customer channel accidentally.
+    if not simulator_paths:
+        non_target_identities = {
+            record.participant_identity
+            for record in recorder.records
+            if record.participant_identity != target_identity
+        }
+        if len(non_target_identities) == 1:
+            simulator_paths = recorder.paths_for_participant(
+                next(iter(non_target_identities))
+            )
     audio_directory = case_directory / "audio"
     input_path = _collapse_recordings(
         simulator_paths,
@@ -2370,6 +2963,27 @@ def _attach_recordings(
         }
         for record in recorder.records
     ]
+    outcome.metadata["recording_diagnostics"] = {
+        "simulator_identity": simulator_identity,
+        "target_identity": target_identity,
+        "target_track_sid": target_track_sid,
+        "simulator_track_count": len(simulator_paths),
+        "target_track_count": len(target_paths),
+        "recorder_error_types": [type(error).__name__ for error in recorder.errors],
+    }
+    if combined_path is None:
+        logger.warning(
+            "LiveKit call completed without captured audio tracks",
+            extra={
+                "simulator_identity": simulator_identity,
+                "target_identity": target_identity,
+                "target_track_sid": target_track_sid,
+                "recorded_track_count": len(recorder.records),
+                "recorder_error_types": [
+                    type(error).__name__ for error in recorder.errors
+                ],
+            },
+        )
     speech_starts = [
         float(message["started_speaking_at"])
         for message in outcome.messages
@@ -2378,9 +2992,7 @@ def _attach_recordings(
     if recorder.recording_started_at is not None and speech_starts:
         outcome.metadata["recording_offset_ms"] = max(
             0,
-            round(
-                (min(speech_starts) - recorder.recording_started_at) * 1000
-            ),
+            round((min(speech_starts) - recorder.recording_started_at) * 1000),
         )
 
 
@@ -2555,7 +3167,7 @@ def _safe_provider_error_details(
             code_value = code_value if code_value is not None else code
     else:
         code_value = None
-    status = getattr(exc, "status", None)
+    status = getattr(exc, "status", None) or getattr(exc, "status_code", None)
     details: dict[str, object] = {
         "operation": operation,
         "exception_type": type(exc).__name__,
@@ -2639,6 +3251,83 @@ async def _ensure_sip_inbound_dispatch(
         )
     )
     return resp.sip_dispatch_rule_id, True
+
+
+async def _ensure_room_absent(
+    api_client: api.LiveKitAPI, room_name: str, *, poll_interval: float = 0.5
+) -> int:
+    """Make ``room_name`` absent before the caller (re-)creates it.
+
+    The pool's dispatch rule stays live for the whole run, so an inbound call
+    can re-create this room between our own delete and our next poll — hence
+    the re-delete inside the loop rather than a single delete-then-poll. No
+    internal deadline: the caller bounds this with ``asyncio.wait_for``.
+    """
+
+    try:
+        await api_client.room.delete_room(api.DeleteRoomRequest(room=room_name))
+    except Exception as exc:  # noqa: BLE001
+        if not _is_not_found(exc):
+            raise
+    polls = 0
+    while True:
+        resp = await api_client.room.list_rooms(api.ListRoomsRequest(names=[room_name]))
+        polls += 1
+        if not resp.rooms:
+            return polls
+        try:
+            await api_client.room.delete_room(api.DeleteRoomRequest(room=room_name))
+        except Exception as exc:  # noqa: BLE001
+            if not _is_not_found(exc):
+                raise
+        await asyncio.sleep(poll_interval if polls < 4 else 5.0)
+
+
+def _unexpected_participants(
+    room, *, simulator_identity: str, recorder_identity: str
+) -> set[str]:
+    return {str(p.identity) for p in room.remote_participants.values()} - {
+        simulator_identity,
+        recorder_identity,
+    }
+
+
+# LiveKit: the other party's number on a SIP participant (the caller, for an
+# inbound call). sip.trunkPhoneNumber is OUR number — never use it.
+_SIP_REMOTE_NUMBER_ATTRIBUTE = "sip.phoneNumber"
+
+
+def _number_digits(value) -> str:
+    text = str(value or "")
+    if text.startswith("sip:"):
+        text = text[len("sip:") :]
+        text = text.split("@", 1)[0]
+        text = text.split(";", 1)[0]
+    return re.sub(r"\D", "", text)
+
+
+def _caller_matches(attributes, expected: str | None) -> bool | None:
+    if not expected:
+        return None
+    observed = attributes.get(_SIP_REMOTE_NUMBER_ATTRIBUTE) if attributes else None
+    if not observed:
+        return None
+    expected_digits = _number_digits(expected)
+    observed_digits = _number_digits(observed)
+    if len(expected_digits) < 7 or len(observed_digits) < 7:
+        return None
+    longer, shorter = (
+        (expected_digits, observed_digits)
+        if len(expected_digits) >= len(observed_digits)
+        else (observed_digits, expected_digits)
+    )
+    return longer.endswith(shorter)
+
+
+class _LeasedRoomCallerMismatch(Exception):
+    """Module-private: raised by the leased-room caller check (step 4a), caught
+    by the case's top-level try so the post-try recordings/evidence/metadata
+    block still runs for a call that was billed and answered."""
 
 
 async def _delete_sip_dispatch_rule(api_client: api.LiveKitAPI, rule_id: str) -> None:

--- a/tests/runtime/test_livekit_engine.py
+++ b/tests/runtime/test_livekit_engine.py
@@ -12,8 +12,12 @@ import pytest
 
 pytest.importorskip("livekit")
 
-from fi.simulate.agent.definition import AgentDefinition
-from fi.simulate.recording.room_recorder import mix_recordings, mix_recordings_stereo
+from fi.simulate.agent.definition import AgentDefinition, TelephonyTransport
+from fi.simulate.recording.room_recorder import (
+    RecordedTrack,
+    mix_recordings,
+    mix_recordings_stereo,
+)
 from fi.simulate.runtime import TestCaseStatus as CaseStatus
 from fi.simulate.simulation import bridge as _bridge
 from fi.simulate.simulation.engines import livekit
@@ -58,6 +62,33 @@ def _write_wav(path: Path, samples: np.ndarray, sample_rate: int = 8000) -> None
         wav_file.writeframes(samples.astype(np.int16).tobytes())
 
 
+def test_simulator_identity_carries_fixture_phone_for_repository_agents() -> None:
+    persona = Persona(
+        persona={
+            "name": "Noor",
+            "metadata": {"caller_phone": "+1 (415) 555-0107"},
+        },
+        situation="Cancel my ride.",
+        outcome="The ride is cancelled.",
+    )
+    assert (
+        livekit._simulator_participant_identity(persona, "case_aaaaaaaaaaaa")
+        == "fagi-simulator-phone-14155550107-aaaaaaaaaaaa"
+    )
+
+
+def test_simulator_identity_preserves_legacy_shape_without_valid_phone() -> None:
+    persona = Persona(
+        persona={"name": "Caller", "metadata": {"caller_phone": "unknown"}},
+        situation="I need help.",
+        outcome="The issue is resolved.",
+    )
+    assert (
+        livekit._simulator_participant_identity(persona, "case_bbbbbbbbbbbb")
+        == "fagi-simulator-bbbbbbbbbbbb"
+    )
+
+
 def test_managed_room_names_are_unique_per_run_and_case() -> None:
     agent = _agent(room_mode="managed", agent_name="support-agent")
 
@@ -90,7 +121,10 @@ def test_external_multi_case_run_requires_room_template() -> None:
         )
 
 
-def test_verbatim_room_name_rejects_multi_persona_run() -> None:
+def test_verbatim_room_name_requires_serial_cases(monkeypatch) -> None:
+    # A stray env override of the max-case-concurrency default would let this
+    # test pass for the wrong reason (concurrency already 1), so make it explicit.
+    monkeypatch.delenv("ALK_VOICE_MAX_CASE_CONCURRENCY", raising=False)
     runtime = livekit.LiveKitSimulatorRuntime(
         url="wss://livekit.example.com",
         room_name="sim-slot-03",
@@ -100,15 +134,337 @@ def test_verbatim_room_name_rejects_multi_persona_run() -> None:
 
     with pytest.raises(
         ValueError,
-        match="room_name_verbatim requires a single-persona scenario",
+        match="room_name_verbatim_requires_serial_cases",
     ):
         asyncio.run(
             LiveKitEngine().run(
                 agent_definition=_agent(),
                 livekit_runtime=runtime,
                 scenario=_scenario(2),
+                max_concurrency=2,
             )
         )
+
+
+def test_verbatim_sip_inbound_multi_persona_reuses_the_same_room(
+    monkeypatch,
+) -> None:
+    runtime = livekit.LiveKitSimulatorRuntime(
+        url="wss://livekit.example.com",
+        room_name="sim-slot-03",
+        room_mode="managed",
+        room_name_verbatim=True,
+    )
+    agent = _agent(
+        room_mode="managed", transport=TelephonyTransport(kind="sip_inbound")
+    )
+    engine = LiveKitEngine()
+    captured_room_names: list[str] = []
+
+    async def _fake_run_case(*_args, **kwargs):
+        captured_room_names.append(kwargs["room_name"])
+        return livekit._CaseOutcome(status=CaseStatus.COMPLETED)
+
+    monkeypatch.setattr(engine, "_run_single_test_case", _fake_run_case)
+
+    report = asyncio.run(
+        engine.run(
+            agent_definition=agent,
+            livekit_runtime=runtime,
+            scenario=_scenario(3),
+            max_concurrency=2,
+        )
+    )
+
+    assert captured_room_names == ["sim-slot-03"] * 3
+    assert len(report.results) == 3
+
+
+def test_verbatim_multi_persona_sip_inbound_skips_room_template_requirement(
+    monkeypatch,
+) -> None:
+    runtime = livekit.LiveKitSimulatorRuntime(
+        url="wss://livekit.example.com",
+        room_name="sim-slot-03",  # no {test_case_id}/{run_id} template
+        room_mode="managed",
+        room_name_verbatim=True,
+    )
+    agent = _agent(
+        room_mode="managed", transport=TelephonyTransport(kind="sip_inbound")
+    )
+    engine = LiveKitEngine()
+
+    async def _fake_run_case(*_args, **kwargs):
+        return livekit._CaseOutcome(status=CaseStatus.COMPLETED)
+
+    monkeypatch.setattr(engine, "_run_single_test_case", _fake_run_case)
+
+    try:
+        report = asyncio.run(
+            engine.run(
+                agent_definition=agent,
+                livekit_runtime=runtime,
+                scenario=_scenario(3),
+            )
+        )
+    except ValueError as exc:
+        pytest.fail(f"sip_inbound_room_template_required unexpectedly raised: {exc}")
+
+    assert len(report.results) == 3
+
+
+def test_drain_failure_is_a_failure_of_that_case_only(monkeypatch) -> None:
+    runtime = livekit.LiveKitSimulatorRuntime(
+        url="wss://livekit.example.com",
+        room_name="sim-slot-03",
+        room_mode="managed",
+        room_name_verbatim=True,
+    )
+    agent = _agent(
+        room_mode="managed", transport=TelephonyTransport(kind="sip_inbound")
+    )
+    engine = LiveKitEngine()
+    calls = {"count": 0}
+
+    async def _fake_run_case(*_args, **_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return livekit._failure_outcome(
+                CaseStatus.TIMED_OUT,
+                livekit.FailureStage.PREPARING,
+                "livekit_room_drain_timeout",
+                "The leased simulator room was still occupied when its drain deadline passed",
+                retryable=True,
+            )
+        return livekit._CaseOutcome(status=CaseStatus.COMPLETED)
+
+    monkeypatch.setattr(engine, "_run_single_test_case", _fake_run_case)
+
+    report = asyncio.run(
+        engine.run(
+            agent_definition=agent,
+            livekit_runtime=runtime,
+            scenario=_scenario(3),
+        )
+    )
+
+    assert len(report.results) == 3
+    assert report.results[0].metadata["status"] == CaseStatus.TIMED_OUT.value
+    assert report.results[0].metadata["failure"]["code"] == "livekit_room_drain_timeout"
+    assert report.results[1].metadata["status"] == CaseStatus.COMPLETED.value
+    assert report.results[2].metadata["status"] == CaseStatus.COMPLETED.value
+
+
+class _FakeApiError(Exception):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def test_ensure_room_absent_tolerates_not_found_on_initial_delete() -> None:
+    calls: list[tuple] = []
+
+    async def delete_room(request):
+        calls.append(("delete", request.room))
+        raise _FakeApiError("not_found")
+
+    async def list_rooms(request):
+        calls.append(("list", tuple(request.names)))
+        return SimpleNamespace(rooms=[])
+
+    api_client = SimpleNamespace(
+        room=SimpleNamespace(delete_room=delete_room, list_rooms=list_rooms)
+    )
+
+    polls = asyncio.run(livekit._ensure_room_absent(api_client, "sim-slot-01"))
+
+    assert polls == 1
+    assert calls == [("delete", "sim-slot-01"), ("list", ("sim-slot-01",))]
+
+
+def test_ensure_room_absent_redeletes_when_still_listed_once(monkeypatch) -> None:
+    calls: list[tuple] = []
+    list_responses = [
+        SimpleNamespace(rooms=[SimpleNamespace(name="sim-slot-01")]),
+        SimpleNamespace(rooms=[]),
+    ]
+    real_sleep = asyncio.sleep
+
+    async def _fake_sleep(seconds):
+        # Real backoff sleeps would cost CI 1.5s across these two tests for no
+        # assertion value; yield instead so the poll loop still awaits.
+        await real_sleep(0)
+
+    monkeypatch.setattr(livekit.asyncio, "sleep", _fake_sleep)
+
+    async def delete_room(request):
+        calls.append(("delete", request.room))
+
+    async def list_rooms(request):
+        return list_responses.pop(0)
+
+    api_client = SimpleNamespace(
+        room=SimpleNamespace(delete_room=delete_room, list_rooms=list_rooms)
+    )
+
+    polls = asyncio.run(livekit._ensure_room_absent(api_client, "sim-slot-01"))
+
+    assert polls == 2
+    assert calls == [("delete", "sim-slot-01"), ("delete", "sim-slot-01")]
+
+
+def test_ensure_room_absent_redeletes_when_still_listed_twice(monkeypatch) -> None:
+    calls: list[tuple] = []
+    list_responses = [
+        SimpleNamespace(rooms=[SimpleNamespace(name="sim-slot-01")]),
+        SimpleNamespace(rooms=[SimpleNamespace(name="sim-slot-01")]),
+        SimpleNamespace(rooms=[]),
+    ]
+    real_sleep = asyncio.sleep
+
+    async def _fake_sleep(seconds):
+        # Real backoff sleeps would cost CI 1.5s across these two tests for no
+        # assertion value; yield instead so the poll loop still awaits.
+        await real_sleep(0)
+
+    monkeypatch.setattr(livekit.asyncio, "sleep", _fake_sleep)
+
+    async def delete_room(request):
+        calls.append(("delete", request.room))
+
+    async def list_rooms(request):
+        return list_responses.pop(0)
+
+    api_client = SimpleNamespace(
+        room=SimpleNamespace(delete_room=delete_room, list_rooms=list_rooms)
+    )
+
+    polls = asyncio.run(livekit._ensure_room_absent(api_client, "sim-slot-01"))
+
+    assert polls == 3
+    assert len(calls) == 3
+
+
+def test_ensure_room_absent_propagates_non_not_found_delete_error() -> None:
+    async def delete_room(request):
+        raise _FakeApiError("internal")
+
+    async def list_rooms(request):
+        raise AssertionError("list_rooms should not be called")
+
+    api_client = SimpleNamespace(
+        room=SimpleNamespace(delete_room=delete_room, list_rooms=list_rooms)
+    )
+
+    with pytest.raises(_FakeApiError):
+        asyncio.run(livekit._ensure_room_absent(api_client, "sim-slot-01"))
+
+
+def test_ensure_room_absent_times_out_and_backs_off(monkeypatch) -> None:
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        # A non-yielding stub would never let wait_for's own timeout fire.
+        await real_sleep(0)
+
+    monkeypatch.setattr(livekit.asyncio, "sleep", _fake_sleep)
+
+    async def delete_room(_request):
+        return None
+
+    async def list_rooms(_request):
+        return SimpleNamespace(rooms=[SimpleNamespace(name="sim-slot-01")])
+
+    api_client = SimpleNamespace(
+        room=SimpleNamespace(delete_room=delete_room, list_rooms=list_rooms)
+    )
+
+    async def _run():
+        await asyncio.wait_for(
+            livekit._ensure_room_absent(api_client, "sim-slot-01"),
+            timeout=0.2,
+        )
+
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(_run())
+
+    assert sleep_calls[:5] == [0.5, 0.5, 0.5, 5.0, 5.0]
+
+
+def test_unexpected_participants_excludes_simulator_and_recorder() -> None:
+    room = SimpleNamespace(
+        remote_participants={
+            "sim": SimpleNamespace(identity="fagi-simulator-abc"),
+            "rec": SimpleNamespace(identity="fagi-recorder-abc"),
+            "other": SimpleNamespace(identity="sip-caller-xyz"),
+        }
+    )
+
+    result = livekit._unexpected_participants(
+        room,
+        simulator_identity="fagi-simulator-abc",
+        recorder_identity="fagi-recorder-abc",
+    )
+
+    assert result == {"sip-caller-xyz"}
+
+
+def test_unexpected_participants_empty_when_only_ours() -> None:
+    room = SimpleNamespace(
+        remote_participants={
+            "sim": SimpleNamespace(identity="fagi-simulator-abc"),
+            "rec": SimpleNamespace(identity="fagi-recorder-abc"),
+        }
+    )
+
+    result = livekit._unexpected_participants(
+        room,
+        simulator_identity="fagi-simulator-abc",
+        recorder_identity="fagi-recorder-abc",
+    )
+
+    assert result == set()
+
+
+@pytest.mark.parametrize(
+    "attribute_value, expected",
+    [
+        ("+14155551234", True),
+        ("14155551234", True),
+        ("4155551234", True),
+        ("5551234", True),
+        ("sip:+14155551234@trunk.example.com", True),
+        ("sip:+14155551234@trunk;transport=udp", True),
+        ("+14155559999", False),
+        ("555", None),
+    ],
+)
+def test_caller_matches_suffix_rule(attribute_value, expected) -> None:
+    attributes = {"sip.phoneNumber": attribute_value}
+    assert livekit._caller_matches(attributes, "+14155551234") is expected
+
+
+def test_caller_matches_missing_attribute_is_unverified() -> None:
+    assert livekit._caller_matches({}, "+14155551234") is None
+
+
+def test_caller_matches_no_expected_number_is_unverified() -> None:
+    assert livekit._caller_matches({"sip.phoneNumber": "+14155551234"}, None) is None
+
+
+def test_caller_matches_national_format_mismatch_is_documented_limitation() -> None:
+    # A national-format caller ID (0-prefixed instead of the country code) is a
+    # known false mismatch, not a false match — loud and retryable.
+    assert (
+        livekit._caller_matches({"sip.phoneNumber": "0612345678"}, "+33612345678")
+        is False
+    )
+
+
+def test_number_digits_strips_sip_uri_user_part_and_params() -> None:
+    assert livekit._number_digits("sip:+1415@host9;x=1") == "1415"
 
 
 def test_missing_credentials_is_typed_failure_not_transcript(monkeypatch) -> None:
@@ -395,6 +751,39 @@ def test_target_audio_selection_uses_explicit_identity() -> None:
     assert selected.audio_track_sid == "track-target"
 
 
+def test_target_audio_selection_ignores_background_track_from_same_agent() -> None:
+    audio_kind = livekit.rtc.TrackKind.KIND_AUDIO
+    room = SimpleNamespace(
+        remote_participants={
+            "target": SimpleNamespace(
+                identity="drive-thru-agent",
+                sid="participant-target",
+                track_publications={
+                    "ambient": SimpleNamespace(
+                        sid="track-ambient",
+                        name="background_audio",
+                        kind=audio_kind,
+                    ),
+                    "speech": SimpleNamespace(
+                        sid="track-speech",
+                        name="roomio_audio",
+                        kind=audio_kind,
+                    ),
+                },
+            )
+        }
+    )
+
+    selected = livekit._find_target_audio(
+        room,
+        excluded_identities=set(),
+        target_identity="drive-thru-agent",
+    )
+
+    assert selected is not None
+    assert selected.audio_track_sid == "track-speech"
+
+
 def test_recording_mix_uses_only_explicit_paths(tmp_path: Path) -> None:
     first = tmp_path / "simulator.wav"
     second = tmp_path / "target.wav"
@@ -467,6 +856,88 @@ def test_stereo_mix_leaves_missing_side_silent(tmp_path: Path) -> None:
             dtype=np.int16,
         )
     assert samples.tolist() == [0, 2000, 0, 2000]
+
+
+def test_attach_recordings_falls_back_to_all_target_tracks(tmp_path: Path) -> None:
+    simulator = tmp_path / "simulator.wav"
+    target_speech = tmp_path / "target-speech.wav"
+    target_ambient = tmp_path / "target-ambient.wav"
+    for path, samples in (
+        (simulator, np.array([100, 100], dtype=np.int16)),
+        (target_speech, np.array([200, 200], dtype=np.int16)),
+        (target_ambient, np.array([50, 50], dtype=np.int16)),
+    ):
+        _write_wav(path, samples)
+
+    records = (
+        RecordedTrack("sim", "p1", "sim-track", simulator),
+        RecordedTrack("target", "p2", "speech-track", target_speech),
+        RecordedTrack("target", "p2", "ambient-track", target_ambient),
+    )
+    recorder = SimpleNamespace(
+        records=records,
+        errors=(),
+        recording_started_at=None,
+        paths_for_participant=lambda identity, track_sid=None: [
+            record.path
+            for record in records
+            if record.participant_identity == identity
+            and (track_sid is None or record.track_sid == track_sid)
+        ],
+    )
+    outcome = livekit._CaseOutcome(status=CaseStatus.COMPLETED)
+
+    livekit._attach_recordings(
+        outcome,
+        recorder,
+        simulator_identity="sim",
+        target_identity="target",
+        target_track_sid="replaced-readiness-track",
+        case_directory=tmp_path / "case",
+        sample_rate=8000,
+    )
+
+    assert outcome.audio_combined_path is not None
+    assert outcome.audio_output_path is not None
+    assert outcome.metadata["recording_diagnostics"]["target_track_count"] == 2
+
+
+def test_attach_recordings_uses_unambiguous_simulator_identity_fallback(
+    tmp_path: Path,
+) -> None:
+    simulator = tmp_path / "sdk-local-track.wav"
+    target = tmp_path / "target.wav"
+    _write_wav(simulator, np.array([100, 100], dtype=np.int16))
+    _write_wav(target, np.array([200, 200], dtype=np.int16))
+    records = (
+        RecordedTrack("sdk-local-identity", "p1", "sim-track", simulator),
+        RecordedTrack("target", "p2", "target-track", target),
+    )
+    recorder = SimpleNamespace(
+        records=records,
+        errors=(),
+        recording_started_at=None,
+        paths_for_participant=lambda identity, track_sid=None: [
+            record.path
+            for record in records
+            if record.participant_identity == identity
+            and (track_sid is None or record.track_sid == track_sid)
+        ],
+    )
+    outcome = livekit._CaseOutcome(status=CaseStatus.COMPLETED)
+
+    livekit._attach_recordings(
+        outcome,
+        recorder,
+        simulator_identity="expected-simulator-identity",
+        target_identity="target",
+        target_track_sid="target-track",
+        case_directory=tmp_path / "case",
+        sample_rate=8000,
+    )
+
+    assert outcome.audio_input_path == str(simulator)
+    assert outcome.metadata["recording_diagnostics"]["simulator_track_count"] == 1
 
 
 def test_room_recorder_token_is_hidden_subscribe_only() -> None:
@@ -860,9 +1331,7 @@ def test_end_call_signals_runner_after_minimum_balanced_conversation() -> None:
     agent._session = FakeSession()
     speech_handle = FakeSpeechHandle()
 
-    result = asyncio.run(
-        agent.end_call(SimpleNamespace(speech_handle=speech_handle))
-    )
+    result = asyncio.run(agent.end_call(SimpleNamespace(speech_handle=speech_handle)))
     asyncio.run(agent.wait_for_end_speech())
 
     assert result == "Conversation ended."
@@ -1224,6 +1693,129 @@ def test_failed_stop_reasons_never_report_completed(
     assert outcome.status == CaseStatus.FAILED
     assert outcome.failure is not None
     assert outcome.failure.code == failure_code
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [
+            {"role": "assistant", "content": "How can I help?"},
+            {"role": "user", "content": "Please book a ride."},
+            {"role": "assistant", "content": "Your ride is booked."},
+            {"role": "user", "content": "No, nothing else."},
+            {"role": "assistant", "content": "Have a great day, goodbye!"},
+            {"role": "user", "content": "Thanks, bye."},
+        ],
+        [
+            {"role": "assistant", "content": "I cannot book this account."},
+            {"role": "user", "content": "Can somebody help me?"},
+            {"role": "assistant", "content": "I will transfer you to support."},
+            {"role": "user", "content": "Please do."},
+            {"role": "assistant", "content": "I am transferring you now. Please wait."},
+            {"role": "user", "content": "Okay."},
+        ],
+    ],
+)
+def test_agent_first_silence_after_terminal_exchange_is_completed(
+    messages: list[dict[str, str]],
+) -> None:
+    outcome = livekit._conversation_outcome(
+        "conversation_silence_timeout",
+        messages,
+        min_turn_messages=6,
+    )
+
+    assert outcome.status == CaseStatus.COMPLETED
+    assert outcome.failure is None
+    assert outcome.metadata == {
+        "stop_reason": "conversation_silence_timeout",
+        "terminal_exchange_recovered": True,
+    }
+
+
+def test_farewell_only_turns_are_recognised_as_a_closing_loop() -> None:
+    # Shape taken from a call that ran 76 turns trading goodbyes and cost the job its worlds.
+    assert livekit._is_closing_only("Goodbye.")
+    assert livekit._is_closing_only("Alright, thanks, bye!")
+    assert livekit._is_closing_only("Have a great day!")
+
+
+def test_a_turn_carrying_content_is_not_a_closing() -> None:
+    # A farewell that also asks something is still live conversation.
+    assert not livekit._is_closing_only("Goodbye, but can you resend the receipt first?")
+    assert not livekit._is_closing_only("Yes, please book it.")
+    assert not livekit._is_closing_only("")
+
+
+def test_closing_loop_reports_the_call_as_completed() -> None:
+    outcome = livekit._conversation_outcome(
+        "closing_loop",
+        [
+            {"role": "assistant", "content": "Your ride is booked."},
+            {"role": "user", "content": "Thanks, bye!"},
+            {"role": "assistant", "content": "Goodbye!"},
+            {"role": "user", "content": "Goodbye."},
+            {"role": "assistant", "content": "Goodbye!"},
+            {"role": "user", "content": "Goodbye."},
+        ],
+        min_turn_messages=6,
+    )
+
+    assert outcome.status == CaseStatus.COMPLETED
+    assert outcome.failure is None
+
+
+def test_silence_with_untimed_caller_turns_names_the_synthesis() -> None:
+    # Shape taken from a run whose speech synthesis was out of credit: the caller's line reaches
+    # the transcript, but nothing was ever spoken, so the agent's silence is not the agent's fault.
+    outcome = livekit._conversation_outcome(
+        "conversation_silence_timeout",
+        [
+            {
+                "role": "assistant",
+                "content": "Hi Dana, where should the driver pick you up?",
+                "started_speaking_at": 100.0,
+                "stopped_speaking_at": 104.0,
+            },
+            {
+                "role": "user",
+                "content": "Hi, I'd like to book a ride from 88 King Street.",
+                "started_speaking_at": None,
+                "stopped_speaking_at": None,
+            },
+        ],
+        min_turn_messages=6,
+    )
+
+    assert outcome.status == CaseStatus.FAILED
+    assert outcome.failure is not None
+    assert outcome.failure.code == "simulator_tts_silent"
+    assert outcome.failure.retryable is False
+
+
+def test_silence_with_audible_caller_turns_still_reports_a_stall() -> None:
+    outcome = livekit._conversation_outcome(
+        "conversation_silence_timeout",
+        [
+            {
+                "role": "assistant",
+                "content": "Hi Dana, where should the driver pick you up?",
+                "started_speaking_at": 100.0,
+                "stopped_speaking_at": 104.0,
+            },
+            {
+                "role": "user",
+                "content": "I'm at 333 O'Farrell Street.",
+                "started_speaking_at": 105.0,
+                "stopped_speaking_at": 109.0,
+            },
+        ],
+        min_turn_messages=6,
+    )
+
+    assert outcome.status == CaseStatus.FAILED
+    assert outcome.failure is not None
+    assert outcome.failure.code == "conversation_silence_timeout"
 
 
 def test_unsupported_provider_lists_supported_options() -> None:
@@ -1957,9 +2549,7 @@ def test_case_crash_yields_dense_failed_result_without_shifting_order(
     statuses = [r.metadata["status"] for r in report.results]
     assert statuses[2] == CaseStatus.FAILED.value
     assert report.results[2].metadata["failure"]["code"] == "case_execution_error"
-    assert all(
-        statuses[i] == CaseStatus.COMPLETED.value for i in (0, 1, 3, 4)
-    )
+    assert all(statuses[i] == CaseStatus.COMPLETED.value for i in (0, 1, 3, 4))
 
 
 def test_on_case_complete_streams_every_index_including_failed_slot(
@@ -2028,7 +2618,9 @@ def test_dispatch_metadata_empty_by_default():
     # A real target agent flips to outbound/no-greet on any dispatch metadata,
     # so the default must be an empty string (not our simulation context).
     assert livekit._dispatch_metadata_json(_agent()) == ""
-    assert livekit._dispatch_metadata_json(SimpleNamespace(dispatch_metadata=None)) == ""
+    assert (
+        livekit._dispatch_metadata_json(SimpleNamespace(dispatch_metadata=None)) == ""
+    )
     assert livekit._dispatch_metadata_json(SimpleNamespace(dispatch_metadata={})) == ""
 
 
@@ -2245,13 +2837,26 @@ def test_merge_patches_target_turn_missing_stop_timing() -> None:
     # Native target turns reach history via generate_reply(user_input=) with no
     # audio metrics, so stop == start (zero duration) -> bot WPM/latency dead.
     messages = [
-        {"role": "user", "content": "hi", "started_speaking_at": 1.0,
-         "stopped_speaking_at": 2.0},
-        {"role": "assistant", "content": "hello there how can i help",
-         "started_speaking_at": 3.0, "stopped_speaking_at": 3.0},
+        {
+            "role": "user",
+            "content": "hi",
+            "started_speaking_at": 1.0,
+            "stopped_speaking_at": 2.0,
+        },
+        {
+            "role": "assistant",
+            "content": "hello there how can i help",
+            "started_speaking_at": 3.0,
+            "stopped_speaking_at": 3.0,
+        },
     ]
-    captured = [{"content": "hello there how can i help",
-                 "started_speaking_at": 2.5, "stopped_speaking_at": 5.0}]
+    captured = [
+        {
+            "content": "hello there how can i help",
+            "started_speaking_at": 2.5,
+            "stopped_speaking_at": 5.0,
+        }
+    ]
     merged = livekit._merge_captured_target_turns(messages, captured)
     assert len(merged) == 2  # patched in place, not appended
     agent = next(m for m in merged if m["role"] == "assistant")
@@ -2262,14 +2867,24 @@ def test_merge_patches_target_turn_missing_stop_timing() -> None:
 def test_merge_aggregates_partial_target_emissions() -> None:
     # One turn arrives as several partial/extended emissions -> min-start/max-stop.
     messages = [
-        {"role": "assistant", "content": "can we look at options for that",
-         "started_speaking_at": 10.0, "stopped_speaking_at": 10.0},
+        {
+            "role": "assistant",
+            "content": "can we look at options for that",
+            "started_speaking_at": 10.0,
+            "stopped_speaking_at": 10.0,
+        },
     ]
     captured = [
-        {"content": "can we look", "started_speaking_at": 9.0,
-         "stopped_speaking_at": 9.5},
-        {"content": "can we look at options for that",
-         "started_speaking_at": 9.2, "stopped_speaking_at": 12.0},
+        {
+            "content": "can we look",
+            "started_speaking_at": 9.0,
+            "stopped_speaking_at": 9.5,
+        },
+        {
+            "content": "can we look at options for that",
+            "started_speaking_at": 9.2,
+            "stopped_speaking_at": 12.0,
+        },
     ]
     merged = livekit._merge_captured_target_turns(messages, captured)
     assert merged[0]["started_speaking_at"] == 9.0
@@ -2278,21 +2893,41 @@ def test_merge_aggregates_partial_target_emissions() -> None:
 
 def test_merge_does_not_override_real_target_timing() -> None:
     messages = [
-        {"role": "assistant", "content": "genuine turn",
-         "started_speaking_at": 4.0, "stopped_speaking_at": 6.0},
+        {
+            "role": "assistant",
+            "content": "genuine turn",
+            "started_speaking_at": 4.0,
+            "stopped_speaking_at": 6.0,
+        },
     ]
-    captured = [{"content": "genuine turn", "started_speaking_at": 1.0,
-                 "stopped_speaking_at": 99.0}]
+    captured = [
+        {
+            "content": "genuine turn",
+            "started_speaking_at": 1.0,
+            "stopped_speaking_at": 99.0,
+        }
+    ]
     merged = livekit._merge_captured_target_turns(messages, captured)
     assert merged[0]["started_speaking_at"] == 4.0
     assert merged[0]["stopped_speaking_at"] == 6.0
 
 
 def test_merge_appends_trailing_target_turn_with_real_timing() -> None:
-    messages = [{"role": "user", "content": "bye", "started_speaking_at": 5.0,
-                 "stopped_speaking_at": 6.0}]
-    captured = [{"content": "take care now", "started_speaking_at": 7.0,
-                 "stopped_speaking_at": 8.0}]
+    messages = [
+        {
+            "role": "user",
+            "content": "bye",
+            "started_speaking_at": 5.0,
+            "stopped_speaking_at": 6.0,
+        }
+    ]
+    captured = [
+        {
+            "content": "take care now",
+            "started_speaking_at": 7.0,
+            "stopped_speaking_at": 8.0,
+        }
+    ]
     merged = livekit._merge_captured_target_turns(messages, captured)
     assert len(merged) == 2
     trailing = merged[-1]
@@ -2336,9 +2971,7 @@ def test_room_disconnect_ends_conversation() -> None:
     # A native target commonly hangs up by deleting the room; the simulator
     # sees a room disconnect, not a participant_disconnected, and the case
     # idled through the silence backstop before ending.
-    room = _FakeEventRoom(
-        participants={"t": SimpleNamespace(identity="target-agent")}
-    )
+    room = _FakeEventRoom(participants={"t": SimpleNamespace(identity="target-agent")})
 
     class FakeSession:
         history = _BALANCED_HISTORY

--- a/tests/runtime/test_voice_environment.py
+++ b/tests/runtime/test_voice_environment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from fi.simulate.hosted.child_entrypoint import _build_voice_spec
 from fi.simulate.hosted.job import RunnerMode, StartRunnerJob, VoiceRunConfig
@@ -119,6 +120,94 @@ def test_voice_runs_through_simulation_runner(monkeypatch) -> None:
     assert report.test_cases[0].result.transcript
 
 
+def test_hosted_voice_params_drops_unknown_platform_keys(monkeypatch, caplog) -> None:
+    """run_voice_simulation is keyword-only with a closed parameter list, so a
+    platform-sent params key it doesn't know (e.g. a leased-DID slot key the
+    hosted runner splats into voice.params) must be dropped before the call
+    instead of raising TypeError and killing the run. No livekit import
+    needed: run_voice_simulation is monkeypatched at the exact module
+    attribute the plugin calls."""
+    job = _voice_job()
+    job.voice.params["inbound_did"] = "+15557654321"
+    spec = _build_voice_spec(job)
+    persona = spec.scenario.dataset[0]
+    seen: dict = {}
+
+    # Closed signature (no **kwargs) mirroring the real run_voice_simulation's
+    # accepted names for this test's params — deliberately omits inbound_did.
+    async def fake_run_voice_simulation(
+        *,
+        agent_definition,
+        livekit_runtime=None,
+        scenario=None,
+        simulator=None,
+        simulation_run_id=None,
+        on_case_complete=None,
+        on_case_start=None,
+        max_seconds=45.0,
+        record_audio=False,
+    ):
+        seen["max_seconds"] = max_seconds
+        seen["record_audio"] = record_audio
+        return _legacy(persona)
+
+    monkeypatch.setattr(
+        "fi.simulate.voice.run_voice_simulation", fake_run_voice_simulation
+    )
+    with caplog.at_level(logging.WARNING, logger="fi.simulate.environments.voice"):
+        report = asyncio.run(SimulationRunner().run(spec))
+
+    assert report.status == RunStatus.COMPLETED
+    # the call succeeded, proving inbound_did never reached the closed kwargs
+    assert seen == {"max_seconds": 120, "record_audio": False}
+    warnings = [r for r in caplog.records if r.message == "hosted_voice_params_ignored"]
+    assert len(warnings) == 1
+    assert warnings[0].keys == ["inbound_did"]
+
+
+def test_hosted_voice_params_drops_plugin_owned_keys(monkeypatch, caplog) -> None:
+    """A voice.params key that names a kwarg VoiceEnvironmentPlugin.run already
+    passes explicitly (e.g. scenario) must be dropped by the filter before the
+    call, not forwarded via **params — else run_voice_simulation raises
+    TypeError: got multiple values for keyword argument 'scenario'. The fake
+    signature below still accepts scenario as a named parameter (mirroring the
+    real one), so this only passes if the filter reserves plugin-owned names
+    itself rather than relying on the signature to reject them."""
+    job = _voice_job()
+    job.voice.params["scenario"] = "bogus-collision-value"
+    spec = _build_voice_spec(job)
+    persona = spec.scenario.dataset[0]
+    seen: dict = {}
+
+    async def fake_run_voice_simulation(
+        *,
+        agent_definition,
+        livekit_runtime=None,
+        scenario=None,
+        simulator=None,
+        simulation_run_id=None,
+        on_case_complete=None,
+        on_case_start=None,
+        max_seconds=45.0,
+        record_audio=False,
+    ):
+        seen["scenario"] = scenario
+        return _legacy(persona)
+
+    monkeypatch.setattr(
+        "fi.simulate.voice.run_voice_simulation", fake_run_voice_simulation
+    )
+    with caplog.at_level(logging.WARNING, logger="fi.simulate.environments.voice"):
+        report = asyncio.run(SimulationRunner().run(spec))
+
+    assert report.status == RunStatus.COMPLETED
+    # the plugin's own scenario reached the call, not the bogus params value
+    assert seen["scenario"] is spec.scenario
+    warnings = [r for r in caplog.records if r.message == "hosted_voice_params_ignored"]
+    assert len(warnings) == 1
+    assert warnings[0].keys == ["scenario"]
+
+
 def _agent_def(**overrides):
     from fi.simulate.agent.definition import AgentDefinition
 
@@ -172,6 +261,24 @@ def test_required_env_parity_across_transport_kinds() -> None:
         "VAPI_PHONE_NUMBER_ID",
         "LIVEKIT_INBOUND_DID",
     ]
+
+
+def test_retell_evidence_source_reads_api_key_from_env(monkeypatch) -> None:
+    """RetellEvidenceSource(config) with no api_key argument falls back to
+    RETELL_API_KEY from the environment (mirrors Vapi's from_env())."""
+    from fi.simulate.agent.definition import ProviderEvidenceConfig
+    from fi.simulate.evidence.providers.retell import RetellEvidenceSource
+
+    monkeypatch.setenv("RETELL_API_KEY", "env-retell-key")
+    source = RetellEvidenceSource(
+        ProviderEvidenceConfig(
+            provider="retell",
+            call_id_source="originator_response",
+        )
+    )
+    assert source._api_key == "env-retell-key"
+    # The attribute alone doesn't prove the key reaches the wire; the header does.
+    assert source._client.headers["Authorization"] == "Bearer env-retell-key"
 
 
 def test_profile_flags_for_target_adapters() -> None:

--- a/tests/test_acceptance_regressions.py
+++ b/tests/test_acceptance_regressions.py
@@ -21,7 +21,7 @@ from fi.simulate.evidence.providers.vapi import (
     VapiEvidenceSource,
     _extract_vapi_recording_urls,
 )
-from fi.simulate.simulation import generator
+from fi.simulate.simulation import generator, livekit_models
 from fi.simulate.simulation.engines import livekit
 
 
@@ -62,7 +62,9 @@ def test_scenario_generator_uses_configured_llm_provider(
         captured.append(value)
         return FakeLLM()
 
-    monkeypatch.setattr(generator, "build_livekit_llm", build_llm)
+    # The generator imports the builder lazily inside __init__, so the name
+    # resolves in livekit_models at call time, never on the generator module.
+    monkeypatch.setattr(livekit_models, "build_livekit_llm", build_llm)
 
     personas = asyncio.run(
         generator.ScenarioGenerator(_agent(), llm_config=config).generate(

--- a/tests/test_call_originator_factory.py
+++ b/tests/test_call_originator_factory.py
@@ -1,0 +1,923 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fi.simulate.endpoints.originators import (
+    CallOriginator,
+    OriginatorFinalizeResult,
+    build_call_originator,
+    finalize_originator,
+)
+from fi.simulate.endpoints.retell import RetellCallOriginator
+from fi.simulate.endpoints.vapi import VapiCallOriginator
+
+_ENGINE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "fi"
+    / "simulate"
+    / "simulation"
+    / "engines"
+    / "livekit.py"
+)
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+class _Transport:
+    def __init__(
+        self,
+        *,
+        inbound_call_originator: str | None,
+        originator_agent_id: str | None = None,
+        originator_from_number: str | None = None,
+    ) -> None:
+        self.inbound_call_originator = inbound_call_originator
+        self.originator_agent_id = originator_agent_id
+        self.originator_from_number = originator_from_number
+
+
+# --- build_call_originator ------------------------------------------------
+
+
+def test_factory_vapi_transport_calls_from_env_with_no_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAPI_API_KEY", "env-key")
+    monkeypatch.setenv("VAPI_ASSISTANT_ID", "env-assistant")
+    monkeypatch.setenv("VAPI_PHONE_NUMBER_ID", "env-phone")
+    monkeypatch.setenv("LIVEKIT_INBOUND_DID", "+15550000099")
+
+    captured: dict[str, tuple] = {}
+    original = VapiCallOriginator.from_env.__func__
+
+    def _spy(cls: type) -> VapiCallOriginator:
+        captured["called"] = True
+        return original(cls)
+
+    monkeypatch.setattr(VapiCallOriginator, "from_env", classmethod(_spy))
+
+    transport = _Transport(inbound_call_originator="vapi")
+    originator = build_call_originator(transport)
+
+    assert captured.get("called") is True
+    assert isinstance(originator, VapiCallOriginator)
+
+
+def test_factory_retell_transport_calls_from_env_with_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RETELL_API_KEY", "env-key")
+    monkeypatch.setenv("LIVEKIT_INBOUND_DID", "+15550000099")
+    monkeypatch.delenv("RETELL_AGENT_ID", raising=False)
+    monkeypatch.delenv("RETELL_FROM_NUMBER", raising=False)
+
+    transport = _Transport(
+        inbound_call_originator="retell",
+        originator_agent_id="transport-agent",
+        originator_from_number="+15550000001",
+    )
+    originator = build_call_originator(transport)
+
+    assert isinstance(originator, RetellCallOriginator)
+    assert originator._agent_id == "transport-agent"
+    assert originator._from_number == "+15550000001"
+    assert originator._destination == "+15550000099"
+
+
+def test_factory_unsupported_originator_raises_typed_error() -> None:
+    transport = _Transport(inbound_call_originator="bland")
+    with pytest.raises(ValueError, match=r"unsupported_inbound_call_originator: bland"):
+        build_call_originator(transport)
+
+
+# --- structural dial-ordering assertion (C3) -------------------------------
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found")
+
+
+def _contains_call_no_nested_funcs(node: ast.AST, func_name: str) -> bool:
+    """True if node's subtree calls func_name, without descending into a
+    nested FunctionDef/AsyncFunctionDef (a call inside a closure has a line
+    number but no runtime ordering relative to the enclosing statement list).
+    """
+
+    found = False
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, inner: ast.FunctionDef) -> None:  # noqa: N802
+            return
+
+        def visit_AsyncFunctionDef(self, inner: ast.AsyncFunctionDef) -> None:  # noqa: N802
+            return
+
+        def visit_Call(self, call: ast.Call) -> None:  # noqa: N802
+            nonlocal found
+            target = call.func
+            if isinstance(target, ast.Name) and target.id == func_name:
+                found = True
+            elif isinstance(target, ast.Attribute) and target.attr == func_name:
+                found = True
+            self.generic_visit(call)
+
+    _Visitor().visit(node)
+    return found
+
+
+def _is_outcome_none_guard(stmt: ast.stmt) -> bool:
+    return (
+        isinstance(stmt, ast.If)
+        and ast.unparse(stmt.test) == "outcome is not None"
+        and len(stmt.body) == 1
+        and isinstance(stmt.body[0], ast.Return)
+    )
+
+
+def test_dial_ordering_verify_before_guard_before_dial() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+
+    trys = [node for node in fn.body if isinstance(node, ast.Try)]
+    assert len(trys) == 1, "expected exactly one top-level Try in _run_single_test_case"
+    try_node = trys[0]
+
+    verify_hits = [
+        i
+        for i, stmt in enumerate(try_node.body)
+        if _contains_call_no_nested_funcs(stmt, "_ensure_sip_inbound_dispatch")
+    ]
+    guard_hits = [
+        i for i, stmt in enumerate(try_node.body) if _is_outcome_none_guard(stmt)
+    ]
+    dial_hits = [
+        i
+        for i, stmt in enumerate(try_node.body)
+        if _contains_call_no_nested_funcs(stmt, "build_call_originator")
+    ]
+
+    assert len(verify_hits) == 1, verify_hits
+    assert len(guard_hits) == 1, guard_hits
+    assert len(dial_hits) == 1, dial_hits
+
+    i_verify, i_guard, i_dial = verify_hits[0], guard_hits[0], dial_hits[0]
+    assert i_verify < i_guard < i_dial, (i_verify, i_guard, i_dial)
+
+
+def test_engine_has_no_bare_vapi_failure_code_literals() -> None:
+    source = _ENGINE_PATH.read_text()
+    assert '"vapi_call_start_timeout"' not in source
+    assert '"vapi_call_start_failed"' not in source
+
+
+def test_engine_retell_call_id_expression_checks_originator() -> None:
+    source = _ENGINE_PATH.read_text()
+    assert 'inbound_call_originator == "retell"' in source
+
+
+def _find_sync_function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    """Like _find_function, but for a plain (non-async) def — engines/livekit.py
+    itself can't be imported here without the livekit optional dependency
+    (it raises ImportError at module scope), so this is a source-level
+    assertion, not an import + call."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found")
+
+
+def test_engine_safe_provider_error_details_falls_back_to_status_code() -> None:
+    """retell-sdk's APIStatusError exposes status_code, not status, so
+    without this fallback a Retell start-failure outcome's details never
+    carry an http_status. AST-checked (not imported + called) because
+    engines/livekit.py requires the livekit optional dependency, which this
+    environment does not have."""
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_sync_function(tree, "_safe_provider_error_details")
+
+    status_assigns = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "status"
+    ]
+    assert len(status_assigns) == 1, status_assigns
+    value_source = ast.unparse(status_assigns[0].value)
+    # ast.unparse normalises string literals to single quotes, so compare
+    # against the unparse of an equivalent double-quoted reference
+    # expression rather than hand-writing the expected quote style.
+    expected_source = ast.unparse(
+        ast.parse(
+            'getattr(exc, "status", None) or getattr(exc, "status_code", None)',
+            mode="eval",
+        ).body
+    )
+    assert value_source == expected_source, value_source
+
+
+def test_engine_finally_writes_reconciled_call_ids_onto_outcome_metadata() -> None:
+    """Reconcile results must reach the outcome from inside the `finally` —
+    start-failure paths `return outcome` from inside the `try`, so a write
+    that only happens in the later `outcome.metadata.update(...)` block would
+    never fire on exactly the paths where a reconcile can happen."""
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    trys = [node for node in fn.body if isinstance(node, ast.Try)]
+    assert len(trys) == 1, "expected exactly one top-level Try in _run_single_test_case"
+    try_node = trys[0]
+
+    def _is_outcome_metadata_reconciled_write(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.ctx, ast.Store)
+            and ast.unparse(node.value) == "outcome.metadata"
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value == "reconciled_call_ids"
+        )
+
+    hits = [
+        node
+        for stmt in try_node.finalbody
+        for node in ast.walk(stmt)
+        if _is_outcome_metadata_reconciled_write(node)
+    ]
+    assert len(hits) == 1, hits
+
+    # Existence alone isn't enough: a write with the key present but the
+    # value gutted to `[]`, or a guard flipped to `outcome is None`, would
+    # still satisfy the check above while silently reintroducing the bug
+    # this test exists to catch (ids dropped, or the write never firing on
+    # a live outcome). Tie the store to its enclosing guard and confirm the
+    # assigned value is a variable, not a constant/empty-list literal.
+    guarded_writes = [
+        (if_node, assign)
+        for stmt in try_node.finalbody
+        for if_node in ast.walk(stmt)
+        if isinstance(if_node, ast.If)
+        for assign in if_node.body
+        if isinstance(assign, ast.Assign)
+        and len(assign.targets) == 1
+        and _is_outcome_metadata_reconciled_write(assign.targets[0])
+    ]
+    assert len(guarded_writes) == 1, guarded_writes
+    guard_if, write_assign = guarded_writes[0]
+    assert ast.unparse(guard_if.test) == "outcome is not None", ast.unparse(
+        guard_if.test
+    )
+    assert isinstance(write_assign.value, ast.Name), (
+        "outcome.metadata['reconciled_call_ids'] must be assigned a variable "
+        "(the finalize result's ids), not a constant/empty-list literal that "
+        "would mask a lost value"
+    )
+
+
+def test_engine_finally_falls_back_provider_call_id_to_reconciled_orphan() -> None:
+    """A reconciled orphan's first id must feed the evidence hint — a
+    fallback that only lived in the outer scope (or fired unconditionally,
+    clobbering a real provider_call_id) would silently reintroduce
+    "we stopped a billed call and then declined to fetch its record"."""
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    trys = [node for node in fn.body if isinstance(node, ast.Try)]
+    assert len(trys) == 1, "expected exactly one top-level Try in _run_single_test_case"
+    try_node = trys[0]
+
+    fallback_writes = [
+        (if_node, assign)
+        for stmt in try_node.finalbody
+        for if_node in ast.walk(stmt)
+        if isinstance(if_node, ast.If)
+        for assign in if_node.body
+        if isinstance(assign, ast.Assign)
+        and len(assign.targets) == 1
+        and isinstance(assign.targets[0], ast.Name)
+        and assign.targets[0].id == "provider_call_id"
+    ]
+    assert len(fallback_writes) == 1, fallback_writes
+    guard_if, assign = fallback_writes[0]
+    guard_source = ast.unparse(guard_if.test)
+    assert "provider_call_id is None" in guard_source, guard_source
+    assert "reconciled_call_ids" in guard_source, guard_source
+
+
+def test_engine_finally_writes_cleanup_status_as_last_statement() -> None:
+    """cleanup_status/cleanup_errors must be computed after every other
+    cleanup step in the finally has run its `_record_cleanup_error` calls —
+    anything earlier would read cleanup_errors before it is fully populated,
+    so the write belongs at the end, and nowhere else in the finally."""
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    trys = [node for node in fn.body if isinstance(node, ast.Try)]
+    assert len(trys) == 1, "expected exactly one top-level Try in _run_single_test_case"
+    try_node = trys[0]
+
+    assert try_node.finalbody, "finally body is empty"
+    last_stmt = try_node.finalbody[-1]
+    assert isinstance(last_stmt, ast.If), last_stmt
+    assert "outcome" in ast.unparse(last_stmt.test), ast.unparse(last_stmt.test)
+
+    def _is_cleanup_status_write(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.ctx, ast.Store)
+            and ast.unparse(node.value) == "outcome.metadata"
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value == "cleanup_status"
+        )
+
+    last_stmt_writes = [
+        node
+        for stmt in last_stmt.body
+        for node in ast.walk(stmt)
+        if _is_cleanup_status_write(node)
+    ]
+    assert len(last_stmt_writes) == 1, last_stmt_writes
+
+    earlier_writes = [
+        node
+        for stmt in try_node.finalbody[:-1]
+        for node in ast.walk(stmt)
+        if _is_cleanup_status_write(node)
+    ]
+    assert earlier_writes == [], earlier_writes
+
+
+# --- finalize_originator (C3) ----------------------------------------------
+
+
+@dataclass
+class _Call:
+    call_id: str = "call-1"
+
+
+@dataclass
+class FakeOriginator:
+    start_result: Any = field(default_factory=_Call)
+    stop_exc: Exception | None = None
+    reconcile_result: list[str] = field(default_factory=list)
+    reconcile_exc: Exception | None = None
+    close_exc: Exception | None = None
+
+    stop_calls: list[str] = field(default_factory=list)
+    reconcile_calls: list[dict[str, Any]] = field(default_factory=list)
+    close_calls: int = 0
+
+    async def start(self) -> Any:
+        return self.start_result
+
+    async def stop(self, call_id: str) -> None:
+        self.stop_calls.append(call_id)
+        if self.stop_exc is not None:
+            raise self.stop_exc
+
+    async def reconcile_and_stop(
+        self, *, started_after_ms: int, ended_before_ms: int
+    ) -> list[str]:
+        self.reconcile_calls.append(
+            {"started_after_ms": started_after_ms, "ended_before_ms": ended_before_ms}
+        )
+        if self.reconcile_exc is not None:
+            raise self.reconcile_exc
+        return self.reconcile_result
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        if self.close_exc is not None:
+            raise self.close_exc
+
+
+_CASE_STARTED_AT = datetime(2026, 1, 1, tzinfo=timezone.utc)
+_NOW = lambda: _CASE_STARTED_AT + timedelta(seconds=5)  # noqa: E731
+
+
+def test_finalize_with_call_id_stops_and_sets_termination_source() -> None:
+    fake = FakeOriginator()
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id="call-1",
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert fake.stop_calls == ["call-1"]
+    assert fake.reconcile_calls == []
+    assert fake.close_calls == 1
+    assert result.termination_source == "sdk_originator_cleanup"
+    assert result.reconciled_call_ids == []
+    assert result.cleanup_errors == []
+
+
+def test_finalize_without_call_id_reconciles_with_int_ms_and_ordered_window() -> None:
+    fake = FakeOriginator(reconcile_result=["orphan-1"])
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id=None,
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert fake.stop_calls == []
+    assert len(fake.reconcile_calls) == 1
+    call = fake.reconcile_calls[0]
+    assert isinstance(call["started_after_ms"], int)
+    assert isinstance(call["ended_before_ms"], int)
+    assert call["started_after_ms"] < call["ended_before_ms"]
+    assert call["started_after_ms"] == int(_CASE_STARTED_AT.timestamp() * 1000)
+    assert call["ended_before_ms"] == int(_NOW().timestamp() * 1000)
+    assert result.termination_source == "sdk_originator_cleanup"
+    assert result.reconciled_call_ids == ["orphan-1"]
+    assert result.cleanup_errors == []
+    assert fake.close_calls == 1
+
+
+def test_finalize_treats_a_naive_case_started_at_as_utc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A naive datetime must be read as UTC, not local time — assert the naive
+    # case produces the identical started_after_ms as its aware UTC
+    # equivalent, rather than pinning a machine-local-timezone offset. Under
+    # TZ=UTC (e.g. most CI runners) a naive datetime and its aware twin
+    # already share an epoch, so this assertion has no teeth there unless we
+    # force a non-UTC process timezone for the duration of the test.
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset is POSIX-only; cannot pin the process timezone")
+    monkeypatch.setenv("TZ", "Asia/Kolkata")
+    time.tzset()
+    try:
+        naive_started_at = datetime(2026, 1, 1)
+        fake = FakeOriginator(reconcile_result=["orphan-1"])
+        result = _run(
+            finalize_originator(
+                fake,
+                provider_call_id=None,
+                originator_name="retell",
+                case_started_at=naive_started_at,
+                cleanup_timeout=5.0,
+                now=_NOW,
+            )
+        )
+        call = fake.reconcile_calls[0]
+        assert call["started_after_ms"] == int(_CASE_STARTED_AT.timestamp() * 1000)
+        assert result.reconciled_call_ids == ["orphan-1"]
+    finally:
+        # Restore TZ before re-syncing the process timezone: calling tzset()
+        # while the patched TZ is still in os.environ would just reapply
+        # Asia/Kolkata and leave later tests running under it. monkeypatch's
+        # own automatic teardown restores os.environ but never calls
+        # tzset() itself, so undo the env change here, synchronously, before
+        # resetting the C library's idea of local time.
+        monkeypatch.undo()
+        time.tzset()
+
+
+def test_finalize_without_call_id_empty_reconcile_leaves_termination_source_none() -> (
+    None
+):
+    fake = FakeOriginator(reconcile_result=[])
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id=None,
+            originator_name="vapi",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert result.termination_source is None
+    assert result.reconciled_call_ids == []
+    assert result.cleanup_errors == []
+
+
+def test_finalize_stop_raising_still_closes_and_records_one_error() -> None:
+    fake = FakeOriginator(stop_exc=RuntimeError("boom"))
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id="call-1",
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert fake.close_calls == 1
+    assert result.termination_source is None
+    assert len(result.cleanup_errors) == 1
+    op, exc = result.cleanup_errors[0]
+    assert op == "retell_call_stop"
+    assert isinstance(exc, RuntimeError)
+
+
+def test_finalize_reconcile_raising_records_reconcile_tag() -> None:
+    fake = FakeOriginator(reconcile_exc=RuntimeError("list-calls down"))
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id=None,
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert result.termination_source is None
+    assert result.reconciled_call_ids == []
+    assert len(result.cleanup_errors) == 1
+    op, exc = result.cleanup_errors[0]
+    assert op == "retell_call_reconcile"
+    assert isinstance(exc, RuntimeError)
+
+
+def test_finalize_reconcile_type_error_gets_distinct_tag() -> None:
+    fake = FakeOriginator(reconcile_exc=TypeError("bad epoch ms"))
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id=None,
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert len(result.cleanup_errors) == 1
+    op, exc = result.cleanup_errors[0]
+    assert op == "retell_call_reconcile_bad_arguments"
+    assert isinstance(exc, TypeError)
+
+
+def test_finalize_close_raising_records_close_error() -> None:
+    fake = FakeOriginator(close_exc=RuntimeError("client already closed"))
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id="call-1",
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert result.termination_source == "sdk_originator_cleanup"
+    assert len(result.cleanup_errors) == 1
+    op, exc = result.cleanup_errors[0]
+    assert op == "retell_call_close"
+    assert isinstance(exc, RuntimeError)
+
+
+def test_finalize_stop_and_close_both_raising_records_both_errors() -> None:
+    fake = FakeOriginator(
+        stop_exc=RuntimeError("stop failed"),
+        close_exc=RuntimeError("close failed"),
+    )
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id="call-1",
+            originator_name="vapi",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    ops = [op for op, _exc in result.cleanup_errors]
+    assert ops == ["vapi_call_stop", "vapi_call_close"]
+    assert result.termination_source is None
+
+
+def test_finalize_never_raises_even_when_close_raises_and_no_call_id() -> None:
+    fake = FakeOriginator(
+        reconcile_exc=RuntimeError("boom"), close_exc=RuntimeError("boom2")
+    )
+    # Must not raise.
+    result = _run(
+        finalize_originator(
+            fake,
+            provider_call_id=None,
+            originator_name="retell",
+            case_started_at=_CASE_STARTED_AT,
+            cleanup_timeout=5.0,
+            now=_NOW,
+        )
+    )
+    assert isinstance(result, OriginatorFinalizeResult)
+    ops = [op for op, _exc in result.cleanup_errors]
+    assert ops == ["retell_call_reconcile", "retell_call_close"]
+
+
+def test_call_originator_protocol_is_satisfied_by_both_concrete_classes() -> None:
+    # Structural check only (no runtime_checkable) — both classes expose the
+    # full Protocol surface with matching method names.
+    for cls in (VapiCallOriginator, RetellCallOriginator):
+        for method in ("start", "stop", "reconcile_and_stop", "close"):
+            assert hasattr(cls, method)
+    # FakeOriginator (used above) also satisfies CallOriginator structurally.
+    fake: CallOriginator = FakeOriginator()
+    assert hasattr(fake, "start")
+    assert hasattr(fake, "stop")
+    assert hasattr(fake, "reconcile_and_stop")
+    assert hasattr(fake, "close")
+
+
+# --------------------------------------------------------------------------- #
+# Leased-room reuse: structural pins (livekit-free, AST-only)
+# --------------------------------------------------------------------------- #
+def _find_if_with_test(stmts: list[ast.stmt], test_src: str) -> ast.If:
+    for stmt in stmts:
+        if isinstance(stmt, ast.If) and ast.unparse(stmt.test) == test_src:
+            return stmt
+    raise AssertionError(f"no If with test {test_src!r} in {stmts}")
+
+
+def _top_level_try(fn: ast.AsyncFunctionDef) -> ast.Try:
+    trys = [node for node in fn.body if isinstance(node, ast.Try)]
+    assert len(trys) == 1, "expected exactly one top-level Try in _run_single_test_case"
+    return trys[0]
+
+
+def test_drain_precedes_room_create_under_verbatim_guard() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    try_node = _top_level_try(fn)
+
+    managed_if = _find_if_with_test(try_node.body, "managed_room_owned")
+    inner_if = _find_if_with_test(managed_if.body, "not profile.places_outbound_call")
+
+    drain_hits = [
+        i
+        for i, stmt in enumerate(inner_if.body)
+        if _contains_call_no_nested_funcs(stmt, "_ensure_room_absent")
+    ]
+    create_hits = [
+        i
+        for i, stmt in enumerate(inner_if.body)
+        if _contains_call_no_nested_funcs(stmt, "create_room")
+    ]
+    assert len(drain_hits) == 1, drain_hits
+    assert len(create_hits) == 1, create_hits
+    i_drain, i_create = drain_hits[0], create_hits[0]
+    assert i_drain < i_create, (i_drain, i_create)
+
+    drain_stmt = inner_if.body[i_drain]
+    assert isinstance(drain_stmt, ast.If)
+    assert ast.unparse(drain_stmt.test) == "runtime.room_name_verbatim"
+
+    create_stmt = inner_if.body[i_create]
+    assert isinstance(create_stmt, ast.If)
+    assert ast.unparse(create_stmt.test) == "outcome is None"
+
+
+def test_occupancy_check_immediately_precedes_dial() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    try_node = _top_level_try(fn)
+
+    occ_hits = [
+        i
+        for i, stmt in enumerate(try_node.body)
+        if _contains_call_no_nested_funcs(stmt, "_unexpected_participants")
+    ]
+    dial_hits = [
+        i
+        for i, stmt in enumerate(try_node.body)
+        if _contains_call_no_nested_funcs(stmt, "build_call_originator")
+    ]
+    assert len(occ_hits) == 1, occ_hits
+    assert len(dial_hits) == 1, dial_hits
+    i_occ, i_dial = occ_hits[0], dial_hits[0]
+    assert i_occ == i_dial - 1, (i_occ, i_dial)
+
+    occ_stmt = try_node.body[i_occ]
+    assert isinstance(occ_stmt, ast.If)
+    occ_test_src = ast.unparse(occ_stmt.test)
+    assert "runtime.room_name_verbatim" in occ_test_src
+    assert "profile.receives_inbound_call" in occ_test_src
+
+
+def test_occupancy_assigns_outcome_before_return() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    try_node = _top_level_try(fn)
+
+    occ_hits = [
+        stmt
+        for stmt in try_node.body
+        if _contains_call_no_nested_funcs(stmt, "_unexpected_participants")
+    ]
+    assert len(occ_hits) == 1, occ_hits
+    occ_stmt = occ_hits[0]
+    assert isinstance(occ_stmt, ast.If)
+
+    # The occupancy guard body is: compute `unexpected`, then `if unexpected:`
+    # whose own body assigns `outcome` and then returns it.
+    inner_ifs = [
+        node
+        for node in ast.walk(occ_stmt)
+        if isinstance(node, ast.If) and node is not occ_stmt
+    ]
+    assert len(inner_ifs) == 1, inner_ifs
+    inner_if = inner_ifs[0]
+
+    assign_indices = [
+        i
+        for i, stmt in enumerate(inner_if.body)
+        if isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and stmt.targets[0].id == "outcome"
+    ]
+    return_indices = [
+        i for i, stmt in enumerate(inner_if.body) if isinstance(stmt, ast.Return)
+    ]
+    assert len(assign_indices) == 1, assign_indices
+    assert len(return_indices) == 1, return_indices
+    assert assign_indices[0] < return_indices[0]
+
+
+def test_caller_check_immediately_follows_readiness_wait() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    try_node = _top_level_try(fn)
+
+    wait_hits = [
+        i
+        for i, stmt in enumerate(try_node.body)
+        if _contains_call_no_nested_funcs(stmt, "_wait_for_target_audio")
+    ]
+    caller_hits = [
+        i
+        for i, stmt in enumerate(try_node.body)
+        if _contains_call_no_nested_funcs(stmt, "_caller_matches")
+    ]
+    assert len(wait_hits) == 1, wait_hits
+    assert len(caller_hits) == 1, caller_hits
+    i_wait, i_caller = wait_hits[0], caller_hits[0]
+    assert i_caller == i_wait + 1, (i_wait, i_caller)
+
+    caller_stmt = try_node.body[i_caller]
+    assert isinstance(caller_stmt, ast.If)
+    caller_test_src = ast.unparse(caller_stmt.test)
+    for token in (
+        "runtime.room_name_verbatim",
+        "profile.receives_inbound_call",
+        "transport.originator_from_number",
+    ):
+        assert token in caller_test_src, (token, caller_test_src)
+
+    returns = [node for node in ast.walk(caller_stmt) if isinstance(node, ast.Return)]
+    assert returns == [], "the caller check must not return directly"
+
+    # No SECOND `if outcome is not None: return outcome` guard was added
+    # anywhere in the function beyond the one pre-existing occurrence.
+    guard_hits = [node for node in ast.walk(fn) if _is_outcome_none_guard(node)]
+    assert len(guard_hits) == 1, guard_hits
+
+
+def test_wrong_caller_fails_through_exception_handler() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    fn = _find_function(tree, "_run_single_test_case")
+    try_node = _top_level_try(fn)
+
+    caller_hits = [
+        stmt
+        for stmt in try_node.body
+        if _contains_call_no_nested_funcs(stmt, "_caller_matches")
+    ]
+    assert len(caller_hits) == 1, caller_hits
+    caller_stmt = caller_hits[0]
+
+    raises = [
+        node
+        for node in ast.walk(caller_stmt)
+        if isinstance(node, ast.Raise)
+        and node.exc is not None
+        and ast.unparse(node.exc).startswith("_LeasedRoomCallerMismatch")
+    ]
+    assert len(raises) == 1, raises
+
+    handler_types = [
+        ast.unparse(handler.type) if handler.type is not None else None
+        for handler in try_node.handlers
+    ]
+    assert "_LeasedRoomCallerMismatch" in handler_types, handler_types
+    idx_mismatch = handler_types.index("_LeasedRoomCallerMismatch")
+    exception_indices = [i for i, t in enumerate(handler_types) if t == "Exception"]
+    assert exception_indices, handler_types
+    assert all(idx_mismatch < i for i in exception_indices), (
+        idx_mismatch,
+        exception_indices,
+    )
+
+    mismatch_handler = try_node.handlers[idx_mismatch]
+    outcome_assigns = [
+        node
+        for node in ast.walk(mismatch_handler)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "outcome"
+    ]
+    assert len(outcome_assigns) == 1, outcome_assigns
+
+
+def test_leased_room_failure_codes_and_flags() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    pairs: set[tuple[str, bool]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "_failure_outcome":
+            continue
+        args = node.args
+        if len(args) < 3 or not isinstance(args[2], ast.Constant):
+            continue
+        code = args[2].value
+        if not isinstance(code, str) or not code.startswith("livekit_room_"):
+            continue
+        retryable = False
+        for kw in node.keywords:
+            if kw.arg == "retryable" and isinstance(kw.value, ast.Constant):
+                retryable = kw.value.value
+        pairs.add((code, retryable))
+
+    assert pairs == {
+        ("livekit_room_create_timeout", True),
+        ("livekit_room_create_failed", False),
+        ("livekit_room_drain_timeout", True),
+        ("livekit_room_drain_failed", False),
+        ("livekit_room_occupied", True),
+        ("livekit_room_wrong_caller", True),
+    }, pairs
+
+
+def test_leased_room_log_lines_carry_no_identities() -> None:
+    tree = ast.parse(_ENGINE_PATH.read_text())
+    targets = {
+        "leased room drained": {"run_id", "test_case_id", "room_name", "polls"},
+        "leased room occupied before dial": {
+            "run_id",
+            "test_case_id",
+            "room_name",
+            "unexpected_participants",
+        },
+        "leased room wrong caller": {
+            "run_id",
+            "test_case_id",
+            "expected_digits",
+            "observed_digits",
+        },
+        "leased room caller unverified": {"run_id", "test_case_id"},
+    }
+    found: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name not in ("info", "warning"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if not (isinstance(first, ast.Constant) and isinstance(first.value, str)):
+            continue
+        message = first.value
+        if message not in targets:
+            continue
+        extra_kw = next((kw for kw in node.keywords if kw.arg == "extra"), None)
+        assert extra_kw is not None, message
+        assert isinstance(extra_kw.value, ast.Dict), (
+            f"{message!r} extra must be an inline dict literal"
+        )
+        keys = {
+            key.value for key in extra_kw.value.keys if isinstance(key, ast.Constant)
+        }
+        found[message] = keys
+
+    for message, expected_keys in targets.items():
+        assert found.get(message) == expected_keys, (message, found.get(message))

--- a/tests/test_retell_endpoint.py
+++ b/tests/test_retell_endpoint.py
@@ -1,0 +1,1645 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+import retell
+
+from fi.simulate.endpoints.retell import RetellCallOriginator
+from fi.simulate.endpoints.vapi import VapiCallOriginator
+
+_LOGGER_NAME = "fi.simulate.endpoints.retell"
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _originator(
+    handler: Any,
+    *,
+    from_number: str = "+15550000001",
+    destination: str = "+15550000099",
+    agent_id: str = "agent_123",
+) -> tuple[RetellCallOriginator, httpx.AsyncClient]:
+    client = httpx.AsyncClient(
+        base_url="https://api.retellai.com",
+        transport=httpx.MockTransport(handler),
+    )
+    originator = RetellCallOriginator(
+        api_key="test-key",
+        agent_id=agent_id,
+        from_number=from_number,
+        destination=destination,
+        client=client,
+    )
+    return originator, client
+
+
+# --- start() -----------------------------------------------------------
+
+
+def test_retell_originator_posts_create_phone_call() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["authorization"] = request.headers.get("Authorization")
+        captured["body"] = request.content
+        return httpx.Response(
+            201, json={"call_id": "call_123", "call_status": "registered"}
+        )
+
+    async def run() -> None:
+        originator, client = _originator(handler)
+        call = await originator.start()
+        await client.aclose()
+        assert call.call_id == "call_123"
+        assert call.status == "registered"
+
+    _run(run())
+
+    assert captured["path"] == "/v2/create-phone-call"
+    assert captured["authorization"] == "Bearer test-key"
+    assert captured["body"] == (
+        b'{"from_number":"+15550000001","to_number":"+15550000099",'
+        b'"override_agent_id":"agent_123"}'
+    )
+
+
+def test_retell_originator_rejects_missing_response_id() -> None:
+    async def run() -> None:
+        originator, client = _originator(lambda _: httpx.Response(201, json={}))
+        with pytest.raises(ValueError, match="retell_call_response_missing_id"):
+            await originator.start()
+        await client.aclose()
+
+    _run(run())
+
+
+@pytest.mark.parametrize(
+    ("status", "content", "headers"),
+    [
+        (200, b"", {"content-type": "text/plain"}),
+        (204, b"", {}),
+    ],
+)
+def test_retell_originator_rejects_non_json_2xx_response(
+    status: int, content: bytes, headers: dict[str, str]
+) -> None:
+    # A 2xx without a JSON content-type is passed through by the
+    # SDK as raw text (or NoneType for a 204), not the typed
+    # PhoneCallResponse model, so `response.call_id` would raise
+    # AttributeError — getattr(response, "call_id", None) must keep the
+    # contracted ValueError the only failure mode here.
+    async def run() -> None:
+        originator, client = _originator(
+            lambda _: httpx.Response(status, content=content, headers=headers)
+        )
+        with pytest.raises(ValueError, match="retell_call_response_missing_id"):
+            await originator.start()
+        await client.aclose()
+
+    _run(run())
+
+
+def test_retell_originator_start_raises_on_non_2xx() -> None:
+    # The retell-sdk client raises its own typed error hierarchy, not
+    # httpx.HTTPStatusError, for a non-2xx response.
+    async def run() -> None:
+        originator, client = _originator(lambda _: httpx.Response(500))
+        with pytest.raises(retell.APIStatusError):
+            await originator.start()
+        await client.aclose()
+
+    _run(run())
+
+
+# --- stop() --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [200, 202, 204, 404, 422])
+def test_retell_originator_stop_tolerates_expected_statuses(status: int) -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["accept"] = request.headers.get("Accept")
+        return httpx.Response(status)
+
+    async def run() -> None:
+        originator, client = _originator(handler)
+        await originator.stop("call_123")
+        await client.aclose()
+
+    _run(run())
+    assert captured["path"] == "/v2/stop-call/call_123"
+    # Mirror the SDK's own NoneType-cast pattern (call.py
+    # delete(): Accept: */*) rather than advertising a JSON body this
+    # bodyless POST never sends.
+    assert captured["accept"] == "*/*"
+
+
+def test_retell_originator_stop_raises_on_unexpected_status() -> None:
+    # A non-tolerated status is re-raised as the SDK's own typed error, not
+    # httpx.HTTPStatusError.
+    async def run() -> None:
+        originator, client = _originator(lambda _: httpx.Response(500))
+        with pytest.raises(retell.APIStatusError):
+            await originator.stop("call_123")
+        await client.aclose()
+
+    _run(run())
+
+
+def test_retell_originator_never_calls_delete_call() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"calls": []})
+
+    async def run() -> None:
+        originator, client = _originator(handler)
+        await originator.stop("call_123")
+        await originator.reconcile_and_stop(started_after_ms=0, ended_before_ms=1)
+        await client.aclose()
+
+    _run(run())
+    assert all(r.method != "DELETE" for r in requests)
+    assert all("delete-call" not in r.url.path for r in requests)
+
+
+def test_stop_rejects_path_bearing_call_id() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    async def run() -> None:
+        originator, client = _originator(handler)
+        for bad_id in (
+            "a/b",
+            "a?b",
+            "a#b",
+            "a%2f",
+            "a b",
+            "../../v2/delete-call/x",
+            "",
+            ".",
+            "..",
+            "a..b",
+            ".x",
+        ):
+            with pytest.raises(ValueError, match="retell_call_id_invalid"):
+                await originator.stop(bad_id)
+        assert requests == []
+        # '.' and ':' are legitimate call-id characters (not path-bearing);
+        # pin the boundary as accepted, not merely untested.
+        await originator.stop("call_a1b2.c3")
+        await client.aclose()
+
+    _run(run())
+    assert requests[0].url.path == "/v2/stop-call/call_a1b2.c3"
+
+
+def test_reconcile_rejects_path_bearing_call_id_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rows = [
+        {
+            "call_id": "../../v2/delete-call/x",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_700,
+            "call_status": "registered",
+        }
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
+    record = next(
+        r for r in caplog.records if "retell_reconcile_target_without_id" in r.message
+    )
+    assert record.has_id is True
+    assert record.count == 1
+
+
+def test_reconcile_logs_target_without_id_when_call_id_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rows = [
+        {
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_700,
+            "call_status": "registered",
+        }
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
+    record = next(
+        r for r in caplog.records if "retell_reconcile_target_without_id" in r.message
+    )
+    assert record.has_id is False
+    assert record.count == 1
+
+
+def test_reconcile_int_call_id_logs_target_without_id_and_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # `has_id = isinstance(call_id, str)` must short-circuit the
+    # `or` in `if not has_id or not _CALL_ID_PATTERN.fullmatch(call_id)`
+    # before `fullmatch` ever sees a non-str call_id — `fullmatch(7)` raises
+    # TypeError. No prior test drove a non-str, non-missing call_id (only a
+    # path-bearing string and a fully-absent field), so this row is
+    # otherwise a valid target: correct destination, from_number, window and
+    # status.
+    rows = [
+        {
+            "call_id": 7,
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_700,
+            "call_status": "registered",
+        }
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
+    record = next(
+        r for r in caplog.records if "retell_reconcile_target_without_id" in r.message
+    )
+    assert record.has_id is False
+    assert record.count == 1
+
+
+# --- from_env() ------------------------------------------------------------
+
+
+def test_retell_originator_from_env_reports_all_missing_sorted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "RETELL_API_KEY",
+        "RETELL_AGENT_ID",
+        "RETELL_FROM_NUMBER",
+        "LIVEKIT_INBOUND_DID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        RetellCallOriginator.from_env()
+
+    message = str(excinfo.value)
+    assert message.startswith("retell_originator_config_missing: ")
+    missing = message.split(": ", 1)[1].split(", ")
+    assert missing == sorted(missing)
+    assert missing == [
+        "LIVEKIT_INBOUND_DID",
+        "RETELL_AGENT_ID",
+        "RETELL_API_KEY",
+        "RETELL_FROM_NUMBER",
+    ]
+
+
+def test_retell_originator_from_env_transport_beats_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RETELL_API_KEY", "env-key")
+    monkeypatch.setenv("RETELL_AGENT_ID", "env-agent")
+    monkeypatch.setenv("RETELL_FROM_NUMBER", "+15550000002")
+    monkeypatch.setenv("LIVEKIT_INBOUND_DID", "+15550000099")
+
+    class _Transport:
+        originator_agent_id = "transport-agent"
+        originator_from_number = "+15550000001"
+
+    originator = RetellCallOriginator.from_env(_Transport())
+    assert originator._agent_id == "transport-agent"
+    assert originator._from_number == "+15550000001"
+    assert originator._destination == "+15550000099"
+
+
+def test_retell_originator_from_env_falls_back_when_transport_lacks_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RETELL_API_KEY", "env-key")
+    monkeypatch.setenv("RETELL_AGENT_ID", "env-agent")
+    monkeypatch.setenv("RETELL_FROM_NUMBER", "+15550000002")
+    monkeypatch.setenv("LIVEKIT_INBOUND_DID", "+15550000099")
+
+    class _EmptyTransport:
+        pass
+
+    originator = RetellCallOriginator.from_env(_EmptyTransport())
+    assert originator._agent_id == "env-agent"
+    assert originator._from_number == "+15550000002"
+
+    originator_no_transport = RetellCallOriginator.from_env(None)
+    assert originator_no_transport._agent_id == "env-agent"
+
+
+# --- reconcile_and_stop(): blast-radius fencing ----------------------------
+
+
+def _list_calls_handler(rows: list[dict[str, Any]], capture: dict[str, Any]) -> Any:
+    # {"items": rows} — the real v3 CallListResponse envelope shape
+    # (retell/types/call_list_response.py, PLAN D12a): a paginated object
+    # with items/has_more/pagination_key/total, not a bare array or the
+    # older {"calls": [...]} dict. See _bare_list_calls_handler and
+    # _calls_key_calls_handler below for the two legacy shapes this
+    # kit still tolerates.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            capture["list_body"] = request.content
+            capture["list_timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200, json={"items": rows})
+        if request.url.path.startswith("/v2/stop-call/"):
+            capture.setdefault("stopped_ids", []).append(
+                request.url.path.rsplit("/", 1)[-1]
+            )
+            capture["stop_timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    return handler
+
+
+def _bare_list_calls_handler(
+    rows: list[dict[str, Any]], capture: dict[str, Any]
+) -> Any:
+    # A bare JSON array — not what the real v3 API sends (see
+    # _list_calls_handler above), but the installed 5.64 SDK still
+    # constructs one CallListResponse per top-level array element
+    # (extra="allow" absorption, probed), and reconcile_and_stop keeps a
+    # legacy isinstance(response, list) branch for it. Exercised by the
+    # fence-behaviour tests below purely as a convenient row-carrying
+    # transport, and pinned directly by
+    # test_reconcile_stops_target_row_legacy_bare_list.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            capture["list_body"] = request.content
+            capture["list_timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200, json=rows)
+        if request.url.path.startswith("/v2/stop-call/"):
+            capture.setdefault("stopped_ids", []).append(
+                request.url.path.rsplit("/", 1)[-1]
+            )
+            capture["stop_timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    return handler
+
+
+def _calls_key_calls_handler(
+    rows: list[dict[str, Any]], capture: dict[str, Any]
+) -> Any:
+    # {"calls": rows} — a pre-D12a legacy dict shape. The installed 5.64
+    # SDK folds this into a CallListResponse with items=None and an extra
+    # "calls" field (probed); reconcile_and_stop's model_dump fallback
+    # branch hands it back to _select_call_rows, which still recognises
+    # the "calls" key. Kept only for
+    # test_reconcile_stops_target_row_legacy_calls_key.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            capture["list_body"] = request.content
+            capture["list_timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200, json={"calls": rows})
+        if request.url.path.startswith("/v2/stop-call/"):
+            capture.setdefault("stopped_ids", []).append(
+                request.url.path.rsplit("/", 1)[-1]
+            )
+            capture["stop_timeout"] = request.extensions.get("timeout")
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    return handler
+
+
+def test_reconcile_sends_v3_typed_filter_criteria_and_limit_50() -> None:
+    # PLAN D12 (supersedes D10a): retell-sdk 5.64+'s AsyncCallResource.list
+    # posts to /v3/list-calls with the v3 {type, op, value} FilterCriteria
+    # vocabulary (retell/types/call_list_params.py) — from_number/to_number
+    # are {"type": "string", "op": "eq", "value": <str>} filters,
+    # start_timestamp is a {"type": "range", "op": "bt", "value": [lower_ms,
+    # upper_ms]} filter. Confirmed on the wire via MockTransport probe
+    # against the installed SDK.
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler([], capture))
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    import json
+
+    body = json.loads(capture["list_body"])
+    assert body["limit"] == 50
+    assert set(body["filter_criteria"].keys()) == {
+        "from_number",
+        "to_number",
+        "start_timestamp",
+    }
+    assert body["filter_criteria"]["from_number"] == {
+        "type": "string",
+        "op": "eq",
+        "value": "+15550000001",
+    }
+    assert body["filter_criteria"]["to_number"] == {
+        "type": "string",
+        "op": "eq",
+        "value": "+15550000099",
+    }
+    assert body["filter_criteria"]["start_timestamp"] == {
+        "type": "range",
+        "op": "bt",
+        "value": [1_000, 2_000],
+    }
+
+
+def test_installed_sdk_list_calls_posts_to_v3() -> None:
+    """Canary for PLAN D12: retell-sdk 5.64+'s AsyncCallResource.list posts
+    to /v3/list-calls with the v3 {type, op, value} FilterCriteria
+    vocabulary, not the /v2 list-valued shape earlier SDK versions used. The
+    reconcile body above (and this test) is hand-typed to match that
+    vocabulary rather than importing the SDK's own request-building code, so
+    nothing here would fail if the SDK moved the endpoint or vocabulary
+    again — only this canary would. If it starts failing, treat it as a
+    signal to re-verify test_reconcile_sends_v3_typed_filter_criteria_and_
+    limit_50 and the reconcile_and_stop request body against the newly
+    installed SDK's source (and, if needed, against the wire via
+    MockTransport) before bumping the pyproject.toml pin.
+    """
+    import inspect
+    import typing
+
+    source = inspect.getsource(retell.resources.call.AsyncCallResource.list)
+    assert '"/v3/list-calls"' in source
+
+    hints = typing.get_type_hints(
+        retell.types.call_list_params.FilterCriteriaFromNumber, include_extras=True
+    )
+    # Required[str], not a sequence (the v2 shape's from_number was
+    # list-valued) — get_type_hints resolves the module's `from __future__
+    # import annotations` string annotations back to real typing objects.
+    assert typing.get_args(hints["value"]) == (str,)
+
+
+def test_reconcile_stops_only_exact_destination_in_window_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Uses the bare-list handler purely as a convenient row-carrying
+    # transport for this fence-behaviour check; the real v3 API returns
+    # the {"items": [...]} envelope (see _list_calls_handler /
+    # test_reconcile_unwraps_v3_items_envelope for the shape itself).
+    rows = [
+        # Newest row of all: if the to_number equality check were ever
+        # removed, latest-wins would pick this row instead of "ours".
+        {
+            "call_id": "wrong_destination",
+            "to_number": "+19990000000",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_900,
+            "call_status": "registered",
+        },
+        {
+            "call_id": "no_destination_field",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_600,
+            "call_status": "registered",
+        },
+        {
+            "call_id": "null_start_timestamp",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": None,
+            "call_status": "registered",
+        },
+        {
+            "call_id": "ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_700,
+            "call_status": "registered",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["ours"]
+    assert capture.get("stopped_ids") == ["ours"]
+    assert any(
+        "retell_reconcile_no_start_timestamp" in r.message for r in caplog.records
+    )
+
+
+def test_reconcile_never_stops_out_of_window_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Uses the bare-list handler purely as a convenient row-carrying
+    # transport for this fence-behaviour check; the real v3 API returns
+    # the {"items": [...]} envelope (see _list_calls_handler /
+    # test_reconcile_unwraps_v3_items_envelope for the shape itself).
+    rows = [
+        {
+            "call_id": "in_window_ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_700,
+            "call_status": "registered",
+        },
+        # Newest row of all, our DID, and stoppable status — if the
+        # client-side window recheck were ever removed, latest-wins would
+        # pick this row over the in-window one.
+        {
+            "call_id": "out_of_window_ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 999_999_999,
+            "call_status": "ongoing",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["in_window_ours"]
+    assert capture.get("stopped_ids") == ["in_window_ours"]
+    assert any("retell_reconcile_out_of_window" in r.message for r in caplog.records)
+
+
+def test_reconcile_drops_from_number_mismatch_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The server-side from_number filter is unproven; an
+    # in-window, correctly-destined, stoppable-status row must still not be
+    # stopped if its from_number isn't ours. Sweep several mismatched
+    # formats the same way the destination-mismatch and
+    # ambiguous-row siblings do (tests below), so a future edit that adds
+    # the raw from_number values to this log's `extra=` can't slip past
+    # silently.
+    rows = [
+        {
+            "call_id": "wrong_from_number",
+            "to_number": "+15550000099",
+            "from_number": "+19990000000",
+            "start_timestamp": 1_700,
+            "call_status": "ongoing",
+        },
+        {
+            "call_id": "spaced_from_number",
+            "to_number": "+15550000099",
+            "from_number": "+1 555 000 0001",
+            "start_timestamp": 1_710,
+            "call_status": "ongoing",
+        },
+        {
+            "call_id": "no_plus_from_number",
+            "to_number": "+15550000099",
+            "from_number": "15550000001",
+            "start_timestamp": 1_720,
+            "call_status": "ongoing",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
+    record = next(
+        r
+        for r in caplog.records
+        if "retell_reconcile_from_number_mismatch" in r.message
+    )
+    assert record.dropped == 3
+    # The raw from_number values — including formatting variants that are
+    # *not* exact matches (spaces, missing "+") — must never leave the
+    # process in this record, under any attribute name.
+    assert not hasattr(record, "observed_from_numbers")
+    row_numbers = {"+19990000000", "+1 555 000 0001", "15550000001"}
+    for value in vars(record).values():
+        items = value if isinstance(value, (list, tuple, set)) else [value]
+        for item in items:
+            assert item not in row_numbers
+
+
+def test_reconcile_status_fence_only_registered_or_ongoing() -> None:
+    # Uses the bare-list handler purely as a convenient row-carrying
+    # transport for this fence-behaviour check; the real v3 API returns
+    # the {"items": [...]} envelope (see _list_calls_handler /
+    # test_reconcile_unwraps_v3_items_envelope for the shape itself).
+    rows = [
+        # Newest row of all, but "ended" is not stoppable.
+        {
+            "call_id": "ended_ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_900,
+            "call_status": "ended",
+        },
+        {
+            "call_id": "ongoing_upper",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_700,
+            "call_status": "ONGOING",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["ongoing_upper"]
+    assert capture.get("stopped_ids") == ["ongoing_upper"]
+
+
+def test_reconcile_two_matching_rows_stops_newer_and_logs_ambiguous(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Uses the bare-list handler purely as a convenient row-carrying
+    # transport for this fence-behaviour check; the real v3 API returns
+    # the {"items": [...]} envelope (see _list_calls_handler /
+    # test_reconcile_unwraps_v3_items_envelope for the shape itself).
+    rows = [
+        {
+            "call_id": "older",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_500,
+            "call_status": "ongoing",
+        },
+        {
+            "call_id": "newer",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_800,
+            "call_status": "registered",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["newer"]
+    assert capture.get("stopped_ids") == ["newer"]
+    record = next(
+        r for r in caplog.records if "retell_reconcile_ambiguous" in r.message
+    )
+    assert record.left_alone == 1
+    assert record.stopped_call_id == "newer"
+    # The row we left alone is a third-party id and must never leave the
+    # process in this record, under any attribute name.
+    for value in vars(record).values():
+        items = value if isinstance(value, (list, tuple, set)) else [value]
+        for item in items:
+            assert item != "older"
+
+
+def test_reconcile_no_destination_field_at_all_stops_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rows = [
+        {
+            "call_id": "a",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_500,
+            "call_status": "registered",
+        },
+        {
+            "call_id": "b",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_600,
+            "call_status": "ongoing",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
+    assert any(
+        "retell_reconcile_no_destination_field" in r.message for r in caplog.records
+    )
+
+
+def test_reconcile_destination_mismatch_logs_count_not_raw_numbers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rows = [
+        {
+            "call_id": "a",
+            "to_number": "+19990000001",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_500,
+            "call_status": "registered",
+        },
+        {
+            "call_id": "b",
+            "to_number": "+19990000002",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_600,
+            "call_status": "ongoing",
+        },
+        # Non-scalar to_number values must never reach the set comprehension
+        # used to count distinct values, and must never raise; they are
+        # treated as "no usable destination" like a missing field.
+        {
+            "call_id": "c",
+            "to_number": ["+19990000003"],
+            "from_number": "+15550000001",
+            "start_timestamp": 1_620,
+            "call_status": "ongoing",
+        },
+        {
+            "call_id": "d",
+            "to_number": {},
+            "from_number": "+15550000001",
+            "start_timestamp": 1_640,
+            "call_status": "ongoing",
+        },
+        # A duplicate of row "a"'s destination: makes count (3) and
+        # distinct_observed (2) diverge, so distinct_observed can't be
+        # confused with a plain row count.
+        {
+            "call_id": "e",
+            "to_number": "+19990000001",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_650,
+            "call_status": "registered",
+        },
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
+    record = next(
+        r
+        for r in caplog.records
+        if "retell_reconcile_destination_mismatch" in r.message
+    )
+    # Our own leased DID may appear (it's ours, not the customer's data).
+    assert record.destination == "+15550000099"
+    # The raw callee numbers must never leave the process in this record.
+    assert not hasattr(record, "observed_to_numbers")
+    assert record.distinct_observed == 2
+    assert record.count == 3
+    row_numbers = {"+19990000001", "+19990000002", "+19990000003"}
+    for value in vars(record).values():
+        items = value if isinstance(value, (list, tuple, set)) else [value]
+        for item in items:
+            assert item not in row_numbers
+
+
+def test_reconcile_zero_rows_logs_no_candidates(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler([], capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert any("retell_reconcile_no_candidates" in r.message for r in caplog.records)
+
+
+def test_reconcile_stops_target_row_legacy_bare_list() -> None:
+    # Pins the legacy bare-JSON-array shape (see _bare_list_calls_handler):
+    # not what the real v3 API sends, but a pre-5.64/compat path the
+    # installed SDK still constructs a usable response from, so
+    # reconcile_and_stop must keep stopping a valid target through it.
+    rows = [
+        {
+            "call_id": "ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_500,
+            "call_status": "registered",
+        }
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_bare_list_calls_handler(rows, capture))
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["ours"]
+    assert capture.get("stopped_ids") == ["ours"]
+
+
+def test_reconcile_stops_target_row_legacy_calls_key() -> None:
+    # Pins the legacy {"calls": [...]} dict shape (see
+    # _calls_key_calls_handler): the installed 5.64 SDK folds it into a
+    # CallListResponse with items=None and an extra "calls" field;
+    # reconcile_and_stop's model_dump fallback branch must still hand it to
+    # _select_call_rows and find the target.
+    rows = [
+        {
+            "call_id": "ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_500,
+            "call_status": "registered",
+        }
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_calls_key_calls_handler(rows, capture))
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["ours"]
+    assert capture.get("stopped_ids") == ["ours"]
+
+
+def test_reconcile_unwraps_v3_items_envelope() -> None:
+    # PLAN D12a: the real v3 CallListResponse envelope — items plus the
+    # pagination metadata fields — must unwrap to the target row and issue
+    # a stop, not just a bare {"items": rows} shortcut.
+    capture: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            return httpx.Response(
+                200,
+                json={
+                    "items": [_VALID_TARGET_ROW],
+                    "has_more": False,
+                    "pagination_key": None,
+                    "total": 1,
+                },
+            )
+        if request.url.path.startswith("/v2/stop-call/"):
+            capture.setdefault("stopped_ids", []).append(
+                request.url.path.rsplit("/", 1)[-1]
+            )
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["ours"]
+    assert capture.get("stopped_ids") == ["ours"]
+
+
+def test_reconcile_envelope_without_items_is_unexpected_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # An envelope-shaped object with no `items` key at all (not a list, not
+    # missing-but-dict — a genuine CallListResponse with items=None) must
+    # be treated as an unrecognised payload, not silently read as zero
+    # candidates.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            return httpx.Response(200, json={"has_more": False})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    record = next(
+        r for r in caplog.records if "retell_reconcile_unexpected_payload" in r.message
+    )
+    assert record.payload_type == "CallListResponse"
+
+
+_VALID_TARGET_ROW: dict[str, Any] = {
+    "call_id": "ours",
+    "to_number": "+15550000099",
+    "from_number": "+15550000001",
+    "start_timestamp": 1_700,
+    "call_status": "registered",
+}
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_skipped", "expected_result"),
+    [
+        ([_VALID_TARGET_ROW, "junk"], 1, ["ours"]),
+        ([None], 1, []),
+        ([1, 2], 2, []),
+    ],
+)
+def test_reconcile_skips_non_object_bare_list_rows(
+    rows: list[Any],
+    expected_skipped: int,
+    expected_result: list[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A malformed 200 JSON array can contain a non-object element
+    # (str/int/None/nested list) — the SDK's construct_type leaves it as the
+    # raw value rather than a typed row, so it has no model_dump. That must
+    # be skipped and counted, not let AttributeError escape past the
+    # swallow with no log at all — and a valid target elsewhere on the same
+    # page must still be found and stopped.
+    capture: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            return httpx.Response(200, json=rows)
+        if request.url.path.startswith("/v2/stop-call/"):
+            capture.setdefault("stopped_ids", []).append(
+                request.url.path.rsplit("/", 1)[-1]
+            )
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == expected_result
+    assert capture.get("stopped_ids", []) == expected_result
+    record = next(
+        r for r in caplog.records if "retell_reconcile_unexpected_row" in r.message
+    )
+    assert record.skipped == expected_skipped
+
+
+def test_bare_list_row_keeps_to_number_after_model_dump() -> None:
+    # CallResponse is an undiscriminated Union
+    # (Union[WebCallResponse, PhoneCallResponse]) and construct_type always
+    # takes the first variant — probed, a phone-call row always constructs
+    # as WebCallResponse, which declares neither to_number nor from_number.
+    # The fences survive only because pydantic's extra="allow"
+    # (retell/_models.py) carries unknown fields through model_dump. Pin
+    # that directly against the installed SDK so a bump that tightens
+    # `extra` or adds a real discriminator can't silently blind the fences.
+    row = {
+        "call_id": "call_abc",
+        "call_type": "phone_call",
+        "to_number": "+15550000099",
+        "from_number": "+15550000001",
+        "start_timestamp": 1_500,
+        "call_status": "registered",
+        "future_unknown_field": "KEEPME",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[row])
+
+    async def run() -> dict[str, Any]:
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(handler),
+        )
+        sdk_client = retell.AsyncRetell(
+            api_key="test-key", http_client=client, max_retries=0
+        )
+        response = await sdk_client.call.list(filter_criteria={}, limit=1)
+        dumped = response[0].model_dump(mode="json")
+        await client.aclose()
+        return dumped
+
+    dumped = _run(run())
+    assert dumped["to_number"] == "+15550000099"
+    assert dumped["from_number"] == "+15550000001"
+    assert dumped["start_timestamp"] == 1_500
+    assert dumped["call_status"] == "registered"
+    assert dumped["call_id"] == "call_abc"
+    assert dumped["future_unknown_field"] == "KEEPME"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_type"),
+    [(b'"not-a-call-list"', "str"), (b"null", "NoneType")],
+)
+def test_reconcile_logs_unexpected_payload_for_unrecognised_shape(
+    body: bytes, expected_type: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    # An explicit JSON content-type mirrors what the real API always sends;
+    # the SDK only attempts to decode the body as JSON when it sees one.
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=body, headers={"content-type": "application/json"}
+        )
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    record = next(
+        r for r in caplog.records if "retell_reconcile_unexpected_payload" in r.message
+    )
+    assert record.payload_type == expected_type
+    assert not any(
+        "retell_reconcile_no_candidates" in r.message for r in caplog.records
+    )
+
+
+def test_reconcile_swallows_non_json_response_body(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # An explicit JSON content-type is what makes the SDK attempt
+    # to parse this malformed body as JSON at all, raising json.JSONDecodeError
+    # (a ValueError) — this is the ValueError arm of the swallow, distinct
+    # from the transport-error net (test_reconcile_swallows_transport_error)
+    # and from the no-content-type case (test_reconcile_text_html_body_is_
+    # unexpected_payload below), which doesn't raise at all.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"<html>gateway</html>",
+            headers={"content-type": "application/json"},
+        )
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    record = next(r for r in caplog.records if "retell_call_reconcile" in r.message)
+    assert record.phase == "list_calls"
+    assert record.error == "JSONDecodeError"
+
+
+def test_reconcile_text_html_body_is_unexpected_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Without a JSON content-type the SDK does not attempt to
+    # parse the body at all and hands back the raw text — the exact
+    # proxy/WAF-page case the ValueError arm above was written for no
+    # longer raises; it now surfaces as retell_reconcile_unexpected_payload
+    # (payload_type "str") rather than the swallowed-fetch-failure code.
+    # PLAN §8's operator decision table treats the two codes as opposite
+    # signals, so pin which one actually fires here.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>gateway</html>")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    record = next(
+        r for r in caplog.records if "retell_reconcile_unexpected_payload" in r.message
+    )
+    assert record.payload_type == "str"
+
+
+def test_reconcile_full_page_logs_page_full(caplog: pytest.LogCaptureFixture) -> None:
+    rows = [
+        {
+            "call_id": f"call_{i}",
+            "to_number": "+19990000000",
+            "start_timestamp": 1_000 + i,
+            "call_status": "ended",
+        }
+        for i in range(50)
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(_list_calls_handler(rows, capture))
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert any("retell_reconcile_page_full" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        datetime.now(timezone.utc),
+        1000.0,  # a float json.dumps CAN serialize; must still be rejected
+        "1000",  # a numeric string json.dumps CAN serialize
+        True,  # bool is an int subclass; the guard must exclude it
+        None,
+    ],
+)
+def test_reconcile_rejects_non_int_time_args_before_any_request(bad_value: Any) -> None:
+    requested = {"called": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested["called"] = True
+        return httpx.Response(200, json={"calls": []})
+
+    async def run() -> None:
+        originator, client = _originator(handler)
+        with pytest.raises(TypeError, match="requires int epoch ms"):
+            await originator.reconcile_and_stop(
+                started_after_ms=bad_value,  # type: ignore[arg-type]
+                ended_before_ms=2_000,
+            )
+        await client.aclose()
+
+    _run(run())
+    assert requested["called"] is False
+
+
+def test_reconcile_swallows_http_errors() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+
+
+def test_reconcile_swallows_transport_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # retell.APIConnectionError is NOT an httpx.HTTPError subclass
+    # (the SDK wraps every transport failure in its own hierarchy) — this is
+    # the one test that drives an actual transport error through
+    # reconcile_and_stop, rather than a non-2xx status
+    # (test_reconcile_swallows_http_errors above tests the latter).
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    record = next(r for r in caplog.records if "retell_call_reconcile" in r.message)
+    assert record.phase == "list_calls"
+    assert record.error == "APIConnectionError"
+
+
+def test_reconcile_uses_10s_per_request_timeout() -> None:
+    rows = [
+        {
+            "call_id": "ours",
+            "to_number": "+15550000099",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_500,
+            "call_status": "registered",
+        }
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> None:
+        originator, client = _originator(_list_calls_handler(rows, capture))
+        await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+
+    _run(run())
+    for key in ("list_timeout", "stop_timeout"):
+        timeout = capture[key]
+        assert timeout["connect"] == 10.0
+        assert timeout["read"] == 10.0
+
+
+def test_retell_api_base_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RETELL_API_BASE_URL", "https://custom.retell.example")
+    originator = RetellCallOriginator(
+        api_key="k",
+        agent_id="a",
+        from_number="+15550000001",
+        destination="+15550000099",
+    )
+    assert str(originator._client.base_url) == "https://custom.retell.example"
+    _run(originator.close())
+
+
+def test_close_only_closes_owned_client() -> None:
+    async def run() -> None:
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        originator = RetellCallOriginator(
+            api_key="k",
+            agent_id="a",
+            from_number="+15550000001",
+            destination="+15550000099",
+            client=client,
+        )
+        await originator.close()
+        assert client.is_closed is False
+        await client.aclose()
+
+    _run(run())
+
+
+def test_close_closes_client_it_created(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        originator = RetellCallOriginator(
+            api_key="k",
+            agent_id="a",
+            from_number="+15550000001",
+            destination="+15550000099",
+        )
+        await originator.close()
+        assert originator._http.is_closed is True
+
+    _run(run())
+
+
+def test_client_timeout_is_30s_total_10s_connect() -> None:
+    # The default client (used by start()/stop()
+    # outside the reconcile path, which passes its own explicit 10 s
+    # timeout) must be constructed with 30 s total, 10 s connect — assert
+    # on the constructed httpx.Timeout directly rather than inferring it
+    # from wire behaviour.
+    originator = RetellCallOriginator(
+        api_key="k",
+        agent_id="a",
+        from_number="+15550000001",
+        destination="+15550000099",
+    )
+    assert originator._client.timeout == httpx.Timeout(30.0, connect=10.0)
+    assert originator._client.max_retries == 0
+    _run(originator.close())
+
+
+def test_retell_client_constructed_with_max_retries_zero() -> None:
+    # The SDK's own retry loop must never layer hidden retries on top of our
+    # own tolerance/retry contract (the tolerated-stop-status set, the
+    # reconcile guard's swallow-and-log).
+    request_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        return httpx.Response(500)
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        assert originator._client.max_retries == 0
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert request_count["n"] == 1
+
+
+# --- lazy `retell` import (P10-2 hardening) --------------------------------
+
+
+def test_retell_call_originator_requires_retell_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # retell-sdk is optional at the package level (see the module's
+    # try/except ImportError); only RetellCallOriginator — the class that
+    # actually talks to the SDK — must fail loudly, and only at
+    # construction time, when it's unavailable.
+    import fi.simulate.endpoints.retell as retell_module
+
+    monkeypatch.setattr(retell_module, "retell", None)
+    with pytest.raises(RuntimeError, match="retell_sdk_missing"):
+        RetellCallOriginator(
+            api_key="k",
+            agent_id="a",
+            from_number="+15550000001",
+            destination="+15550000099",
+        )
+
+
+def test_import_fi_simulate_endpoints_succeeds_without_retell_sdk() -> None:
+    # A chat/Vapi-only environment may not have retell-sdk installed at
+    # all; importing fi.simulate.endpoints (and this module within it)
+    # must not raise. Run in a subprocess — not this test process — since
+    # `retell` is already imported and cached in sys.modules here.
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.modules['retell'] = None; "
+            "import fi.simulate.endpoints; "
+            "import fi.simulate.endpoints.retell as m; "
+            "assert m.retell is None; "
+            "assert m.AsyncRetell is None; "
+            "print('OK')",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+# --- Vapi's no-op reconcile + from_env -------------------------------------
+
+
+def test_vapi_reconcile_and_stop_is_a_noop() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={})
+
+    async def run() -> list[str]:
+        client = httpx.AsyncClient(
+            base_url="https://api.vapi.ai", transport=httpx.MockTransport(handler)
+        )
+        originator = VapiCallOriginator(
+            api_key="k",
+            assistant_id="a",
+            phone_number_id="p",
+            destination="+15550000099",
+            client=client,
+        )
+        result = await originator.reconcile_and_stop(
+            started_after_ms=1_000, ended_before_ms=2_000
+        )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert calls == []
+
+
+def test_vapi_originator_from_env_reports_all_missing_sorted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "VAPI_API_KEY",
+        "VAPI_ASSISTANT_ID",
+        "VAPI_PHONE_NUMBER_ID",
+        "LIVEKIT_INBOUND_DID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        VapiCallOriginator.from_env()
+
+    message = str(excinfo.value)
+    assert message.startswith("vapi_originator_config_missing: ")
+    missing = message.split(": ", 1)[1].split(", ")
+    assert missing == sorted(missing)
+    assert missing == [
+        "LIVEKIT_INBOUND_DID",
+        "VAPI_API_KEY",
+        "VAPI_ASSISTANT_ID",
+        "VAPI_PHONE_NUMBER_ID",
+    ]
+
+
+def test_vapi_originator_from_env_builds_originator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAPI_API_KEY", "k")
+    monkeypatch.setenv("VAPI_ASSISTANT_ID", "a")
+    monkeypatch.setenv("VAPI_PHONE_NUMBER_ID", "p")
+    monkeypatch.setenv("LIVEKIT_INBOUND_DID", "+15550000099")
+
+    originator = VapiCallOriginator.from_env()
+    assert originator._assistant_id == "a"
+    assert originator._phone_number_id == "p"
+    assert originator._destination == "+15550000099"
+
+
+def test_reconcile_items_envelope_skips_non_object_rows(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The production shape: a junk element INSIDE the v3 ``items`` envelope.
+    # Pins the explicit ``.items`` unwrap branch — without it the envelope
+    # still resolves through the legacy dict-key fallback, but the per-row
+    # skip count (an operator-facing log code) is silently lost.
+    capture: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            return httpx.Response(
+                200,
+                json={"items": [_VALID_TARGET_ROW, "junk"], "has_more": False},
+            )
+        if request.url.path.startswith("/v2/stop-call/"):
+            capture.setdefault("stopped_ids", []).append(
+                request.url.path.rsplit("/", 1)[-1]
+            )
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == ["ours"]
+    assert capture.get("stopped_ids", []) == ["ours"]
+    record = next(
+        r for r in caplog.records if "retell_reconcile_unexpected_row" in r.message
+    )
+    assert record.skipped == 1
+
+
+def test_reconcile_truncated_empty_page_logs_page_full_not_no_candidates(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # ``has_more`` is the envelope's explicit truncation flag. An empty page
+    # that the server says is truncated must report page_full (guard may
+    # have missed its own call), never no_candidates (the "guard worked,
+    # page genuinely empty" signal the operator decision table keys on).
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v3/list-calls":
+            return httpx.Response(200, json={"items": [], "has_more": True})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async def run() -> list[str]:
+        originator, client = _originator(handler)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    messages = [r.message for r in caplog.records]
+    assert any("retell_reconcile_page_full" in m for m in messages)
+    assert not any("retell_reconcile_no_candidates" in m for m in messages)
+    record = next(
+        r for r in caplog.records if "retell_reconcile_page_full" in r.message
+    )
+    assert record.has_more is True
+    assert record.row_count == 0

--- a/tests/test_retell_endpoint.py
+++ b/tests/test_retell_endpoint.py
@@ -732,7 +732,7 @@ def test_reconcile_status_fence_only_registered_or_ongoing() -> None:
     assert capture.get("stopped_ids") == ["ongoing_upper"]
 
 
-def test_reconcile_two_matching_rows_stops_newer_and_logs_ambiguous(
+def test_reconcile_two_matching_rows_stops_nothing_and_logs_ambiguous(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Uses the bare-list handler purely as a convenient row-carrying
@@ -767,19 +767,19 @@ def test_reconcile_two_matching_rows_stops_newer_and_logs_ambiguous(
         return result
 
     result = _run(run())
-    assert result == ["newer"]
-    assert capture.get("stopped_ids") == ["newer"]
+    # Ambiguity fails closed: nothing is stopped on the customer's account.
+    assert result == []
+    assert "stopped_ids" not in capture
     record = next(
         r for r in caplog.records if "retell_reconcile_ambiguous" in r.message
     )
-    assert record.left_alone == 1
-    assert record.stopped_call_id == "newer"
-    # The row we left alone is a third-party id and must never leave the
-    # process in this record, under any attribute name.
+    assert record.stoppable == 2
+    # Neither in-window row's id may leave the process in this record, under
+    # any attribute name — the log carries counts only.
     for value in vars(record).values():
         items = value if isinstance(value, (list, tuple, set)) else [value]
         for item in items:
-            assert item != "older"
+            assert item not in ("older", "newer")
 
 
 def test_reconcile_no_destination_field_at_all_stops_nothing(
@@ -1262,6 +1262,48 @@ def test_reconcile_full_page_logs_page_full(caplog: pytest.LogCaptureFixture) ->
 
     result = _run(run())
     assert result == []
+    assert any("retell_reconcile_page_full" in r.message for r in caplog.records)
+
+
+def test_reconcile_full_page_with_matching_row_stops_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A full page means the candidate set may be truncated, so our own call
+    # could be off the page. Even a row that matches our line must not be
+    # stopped — fail closed.
+    ours = {
+        "call_id": "ours",
+        "to_number": "+15550000099",
+        "from_number": "+15550000001",
+        "start_timestamp": 1_500,
+        "call_status": "registered",
+    }
+    fillers = [
+        {
+            "call_id": f"filler_{i}",
+            "to_number": "+19990000000",
+            "from_number": "+15550000001",
+            "start_timestamp": 1_000 + i,
+            "call_status": "ended",
+        }
+        for i in range(49)
+    ]
+    capture: dict[str, Any] = {}
+
+    async def run() -> list[str]:
+        originator, client = _originator(
+            _list_calls_handler([ours, *fillers], capture)
+        )
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = await originator.reconcile_and_stop(
+                started_after_ms=1_000, ended_before_ms=2_000
+            )
+        await client.aclose()
+        return result
+
+    result = _run(run())
+    assert result == []
+    assert "stopped_ids" not in capture
     assert any("retell_reconcile_page_full" in r.message for r in caplog.records)
 
 

--- a/tests/test_retell_evidence.py
+++ b/tests/test_retell_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from datetime import datetime, timezone
 
 import httpx
@@ -16,7 +17,10 @@ def test_retell_originator_response_uses_exact_call_id(tmp_path) -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         requested_paths.append(request.url.path)
-        return httpx.Response(200, json={"call_id": "call_retell_123"})
+        # terminal status on the first GET so the poll exits without sleeping
+        return httpx.Response(
+            200, json={"call_id": "call_retell_123", "call_status": "ended"}
+        )
 
     async def run() -> None:
         client = httpx.AsyncClient(
@@ -42,7 +46,7 @@ def test_retell_originator_response_uses_exact_call_id(tmp_path) -> None:
         )
         payload = await source._locate_and_fetch_call()
         await client.aclose()
-        assert payload == {"call_id": "call_retell_123"}
+        assert payload == {"call_id": "call_retell_123", "call_status": "ended"}
 
     asyncio.run(run())
 
@@ -109,3 +113,245 @@ def test_retell_polling_uses_v3_typed_filters(tmp_path) -> None:
         "op": "eq",
         "value": "+14155550100",
     }
+
+
+def test_retell_hint_path_polls_until_ended(tmp_path) -> None:
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        status = "ongoing" if len(requested_paths) == 1 else "ended"
+        return httpx.Response(
+            200, json={"call_id": "call_retell_789", "call_status": status}
+        )
+
+    async def run():
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(handler),
+        )
+        source = RetellEvidenceSource(
+            ProviderEvidenceConfig(
+                provider="retell",
+                call_id_source="originator_response",
+                poll_interval_seconds=0.01,
+                # deadline isn't the subject here; keep it well clear of the two GETs
+                poll_deadline_seconds=5.0,
+            ),
+            api_key="test-key",
+            client=client,
+        )
+        await source.connect(
+            EvidenceContext(
+                run_id="run_retell",
+                test_case_id="case_retell",
+                case_directory=tmp_path,
+                started_at=datetime.now(timezone.utc),
+                call_id_hint="call_retell_789",
+            )
+        )
+        result = await source.fetch_final()
+        await client.aclose()
+        return result
+
+    result = asyncio.run(run())
+    assert requested_paths == [
+        "/v2/get-call/call_retell_789",
+        "/v2/get-call/call_retell_789",
+    ]
+    assert result.summary.available is True
+
+
+def test_retell_hint_path_not_connected_is_terminal_on_first_get(tmp_path) -> None:
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        return httpx.Response(
+            200, json={"call_id": "call_retell_999", "call_status": "not_connected"}
+        )
+
+    async def run():
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(handler),
+        )
+        source = RetellEvidenceSource(
+            ProviderEvidenceConfig(
+                provider="retell",
+                call_id_source="originator_response",
+                poll_interval_seconds=0.01,
+                # deadline isn't the subject here; keep it well clear of the one GET
+                poll_deadline_seconds=5.0,
+            ),
+            api_key="test-key",
+            client=client,
+        )
+        await source.connect(
+            EvidenceContext(
+                run_id="run_retell",
+                test_case_id="case_retell",
+                case_directory=tmp_path,
+                started_at=datetime.now(timezone.utc),
+                call_id_hint="call_retell_999",
+            )
+        )
+        result = await source.fetch_final()
+        await client.aclose()
+        return result
+
+    result = asyncio.run(run())
+    assert requested_paths == ["/v2/get-call/call_retell_999"]
+    assert result.summary.available is True
+
+
+def test_retell_hint_path_deadline_returns_unavailable_without_raising(
+    tmp_path,
+) -> None:
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        # each GET sees one more transcript entry, so "the last payload" is observable
+        return httpx.Response(
+            200,
+            json={
+                "call_id": "call_retell_stuck",
+                "call_status": "ongoing",
+                "transcript_with_tool_calls": [{"role": "agent"}]
+                * len(requested_paths),
+            },
+        )
+
+    async def run():
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(handler),
+        )
+        source = RetellEvidenceSource(
+            ProviderEvidenceConfig(
+                provider="retell",
+                call_id_source="originator_response",
+                poll_interval_seconds=0.01,
+                poll_deadline_seconds=0.05,
+            ),
+            api_key="test-key",
+            client=client,
+        )
+        await source.connect(
+            EvidenceContext(
+                run_id="run_retell",
+                test_case_id="case_retell",
+                case_directory=tmp_path,
+                started_at=datetime.now(timezone.utc),
+                call_id_hint="call_retell_stuck",
+            )
+        )
+        result = await source.fetch_final()
+        await client.aclose()
+        return result
+
+    t0 = time.monotonic()
+    result = asyncio.run(run())
+    elapsed = time.monotonic() - t0
+    assert all(path == "/v2/get-call/call_retell_stuck" for path in requested_paths)
+    assert result.summary.available is False
+    # deadline (0.05s / 0.01s interval) is this poll's only bound -- an ignored
+    # deadline still finishes green but blows past both of these
+    assert 2 <= len(requested_paths) <= 12
+    assert elapsed < 1.0
+    # the last payload survives the deadline: real status, not a "not matched" report
+    assert result.summary.metadata["status"] == "ongoing"
+    assert "reason" not in result.summary.metadata
+    # pins LAST not first: each GET grew the transcript, so this only holds for the last one
+    assert result.summary.metadata["message_count"] == len(requested_paths)
+
+
+def test_retell_hint_path_404_on_get_call_is_unavailable_no_raise(tmp_path) -> None:
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        return httpx.Response(404, json={"error": "not found"})
+
+    async def run():
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(handler),
+        )
+        source = RetellEvidenceSource(
+            ProviderEvidenceConfig(
+                provider="retell",
+                call_id_source="originator_response",
+                poll_interval_seconds=0.01,
+                poll_deadline_seconds=0.05,
+            ),
+            api_key="test-key",
+            client=client,
+        )
+        await source.connect(
+            EvidenceContext(
+                run_id="run_retell",
+                test_case_id="case_retell",
+                case_directory=tmp_path,
+                started_at=datetime.now(timezone.utc),
+                call_id_hint="call_retell_404",
+            )
+        )
+        result = await source.fetch_final()
+        await client.aclose()
+        return result
+
+    result = asyncio.run(run())
+    assert requested_paths == ["/v2/get-call/call_retell_404"]
+    assert result.summary.available is False
+    # hint path has no matching step; a GET failure is "failed", not "no match"
+    assert result.summary.metadata.get("reason") == "retell_get_call_failed"
+
+
+def test_retell_completed_is_not_terminal_and_polls_to_deadline(tmp_path) -> None:
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        # "completed" is not a Retell call_status; it must not stop the poll early
+        return httpx.Response(
+            200, json={"call_id": "call_retell_looping", "call_status": "completed"}
+        )
+
+    async def run():
+        client = httpx.AsyncClient(
+            base_url="https://api.retellai.com",
+            transport=httpx.MockTransport(handler),
+        )
+        source = RetellEvidenceSource(
+            ProviderEvidenceConfig(
+                provider="retell",
+                call_id_source="originator_response",
+                poll_interval_seconds=0.01,
+                poll_deadline_seconds=0.05,
+            ),
+            api_key="test-key",
+            client=client,
+        )
+        await source.connect(
+            EvidenceContext(
+                run_id="run_retell",
+                test_case_id="case_retell",
+                case_directory=tmp_path,
+                started_at=datetime.now(timezone.utc),
+                call_id_hint="call_retell_looping",
+            )
+        )
+        result = await source.fetch_final()
+        await client.aclose()
+        return result
+
+    t0 = time.monotonic()
+    result = asyncio.run(run())
+    elapsed = time.monotonic() - t0
+    assert all(path == "/v2/get-call/call_retell_looping" for path in requested_paths)
+    assert result.summary.available is False
+    # same bound as the deadline test: "completed" never satisfies the terminal check
+    assert 2 <= len(requested_paths) <= 12
+    assert elapsed < 1.0

--- a/tests/test_retell_transport_validation.py
+++ b/tests/test_retell_transport_validation.py
@@ -1,0 +1,412 @@
+"""C1 rejection-rule coverage for the widened TelephonyTransport.
+
+Every ValueError promised by C1's "What the SDK promises" list gets a test
+here, plus proof that widening the originator Literal and generalizing the
+vapi validator strings left Vapi's behavior byte-identical.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from fi.simulate.agent.definition import AgentDefinition
+
+
+def _agent_def(**overrides):
+    base = {"name": "a", "system_prompt": "p"}
+    base.update(overrides)
+    return AgentDefinition.model_validate(base)
+
+
+def _reject(**kwargs) -> str:
+    """Return the raw ValueError text (not pydantic's 'Value error, ...' wrapper)."""
+    with pytest.raises(ValidationError) as exc:
+        _agent_def(**kwargs)
+    (err,) = exc.value.errors()
+    return err["ctx"]["error"].args[0]
+
+
+# --------------------------------------------------------------------------- #
+# sip_outbound rejects originator fields
+# --------------------------------------------------------------------------- #
+def test_sip_outbound_rejects_inbound_call_originator() -> None:
+    with pytest.raises(
+        ValueError, match="sip_outbound cannot set inbound_call_originator"
+    ):
+        _agent_def(
+            transport={
+                "kind": "sip_outbound",
+                "sip_trunk_id": "trunk_1",
+                "sip_call_to": "+15551230000",
+                "sip_number": "+15559990000",
+                "inbound_call_originator": "retell",
+            }
+        )
+
+
+def test_sip_outbound_rejects_originator_agent_id() -> None:
+    # == (not match=) so an appended suffix on this C1-named string fails this test.
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_outbound",
+                "sip_trunk_id": "trunk_1",
+                "sip_call_to": "+15551230000",
+                "sip_number": "+15559990000",
+                "originator_agent_id": "agent_1",
+            }
+        )
+        == "sip_outbound cannot set originator fields"
+    )
+
+
+def test_sip_outbound_rejects_originator_from_number() -> None:
+    # == (not match=) so an appended suffix on this C1-named string fails this test.
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_outbound",
+                "sip_trunk_id": "trunk_1",
+                "sip_call_to": "+15551230000",
+                "sip_number": "+15559990000",
+                "originator_from_number": "+14155551234",
+            }
+        )
+        == "sip_outbound cannot set originator fields"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# sip_inbound: originator fields require inbound_call_originator
+# --------------------------------------------------------------------------- #
+def test_sip_inbound_originator_agent_id_requires_originator() -> None:
+    with pytest.raises(
+        ValueError, match="originator fields require inbound_call_originator"
+    ):
+        _agent_def(transport={"kind": "sip_inbound", "originator_agent_id": "agent_1"})
+
+
+def test_sip_inbound_originator_from_number_requires_originator() -> None:
+    with pytest.raises(
+        ValueError, match="originator fields require inbound_call_originator"
+    ):
+        _agent_def(
+            transport={"kind": "sip_inbound", "originator_from_number": "+14155551234"}
+        )
+
+
+# --------------------------------------------------------------------------- #
+# sip_inbound: the two originator fields are Retell-only (C1) — a Vapi
+# originator reads its config from env and would otherwise silently ignore them.
+# --------------------------------------------------------------------------- #
+def test_sip_inbound_vapi_originator_rejects_originator_agent_id() -> None:
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "vapi",
+                "originator_agent_id": "agent_1",
+            }
+        )
+        == "vapi_originator_does_not_take_originator_fields"
+    )
+
+
+def test_sip_inbound_vapi_originator_rejects_originator_from_number() -> None:
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "vapi",
+                "originator_from_number": "+14155551234",
+            }
+        )
+        == "vapi_originator_does_not_take_originator_fields"
+    )
+
+
+def test_sip_inbound_retell_originator_accepts_both_originator_fields() -> None:
+    agent = _agent_def(
+        transport={
+            "kind": "sip_inbound",
+            "inbound_call_originator": "retell",
+            "originator_agent_id": "agent_1",
+            "originator_from_number": "+14155551234",
+        },
+        provider_evidence={
+            "provider": "retell",
+            "call_id_source": "originator_response",
+        },
+    )
+    assert agent.transport.originator_agent_id == "agent_1"
+    assert agent.transport.originator_from_number == "+14155551234"
+
+
+# --------------------------------------------------------------------------- #
+# sip_inbound: originator_from_number must be E.164
+# --------------------------------------------------------------------------- #
+def test_sip_inbound_rejects_non_e164_originator_from_number() -> None:
+    with pytest.raises(ValueError, match=r"originator_from_number must be E\.164"):
+        _agent_def(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "retell",
+                "originator_from_number": "4155551234",
+            }
+        )
+
+
+# --------------------------------------------------------------------------- #
+# E.164 boundary pin — guards the module-level _E164 regex against drift
+# (e.g. a `.startswith("+")` swap or a `^\+\d+$` loosening).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("number", ["+1234567", "+123456789012345"])
+def test_originator_from_number_accepts_e164_boundaries(number: str) -> None:
+    agent = _agent_def(
+        transport={
+            "kind": "sip_inbound",
+            "inbound_call_originator": "retell",
+            "originator_from_number": number,
+        },
+        provider_evidence={
+            "provider": "retell",
+            "call_id_source": "originator_response",
+        },
+    )
+    assert agent.transport.originator_from_number == number
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        "+123456",
+        "+1234567890123456",
+        "+01234567",
+        "4155550123",
+        "+1 415 555 0123",
+        "+1415555012a",
+        "+14155550123\n",
+    ],
+)
+def test_originator_from_number_rejects_non_e164(number: str) -> None:
+    with pytest.raises(ValueError, match=r"originator_from_number must be E\.164"):
+        _agent_def(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "retell",
+                "originator_from_number": number,
+            }
+        )
+
+
+# --------------------------------------------------------------------------- #
+# _E164 uses .fullmatch (not .match): "$" also matches before a trailing
+# newline, so pin the two pre-existing sip_outbound sites against it too.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("field", ["sip_call_to", "sip_number"])
+def test_sip_outbound_rejects_trailing_newline(field: str) -> None:
+    transport = {
+        "kind": "sip_outbound",
+        "sip_trunk_id": "trunk_1",
+        "sip_call_to": "+15551230000",
+        "sip_number": "+15559990000",
+        field: "+14155551234\n",
+    }
+    with pytest.raises(ValueError, match=rf"sip_outbound requires E\.164 {field}"):
+        _agent_def(transport=transport)
+
+
+# --------------------------------------------------------------------------- #
+# sip_inbound: originator_agent_id must be non-empty when set (None stays
+# forward-compatible with jobs written before these fields existed).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("agent_id", ["", "   "])
+def test_sip_inbound_rejects_empty_originator_agent_id(agent_id: str) -> None:
+    # == (not match=) so an appended suffix on this C1-named string fails this test.
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "retell",
+                "originator_agent_id": agent_id,
+            }
+        )
+        == "originator_agent_id must be non-empty when set"
+    )
+
+
+def test_sip_inbound_accepts_none_originator_agent_id() -> None:
+    agent = _agent_def(
+        transport={
+            "kind": "sip_inbound",
+            "inbound_call_originator": "retell",
+        },
+        provider_evidence={
+            "provider": "retell",
+            "call_id_source": "originator_response",
+        },
+    )
+    assert agent.transport.originator_agent_id is None
+
+
+# --------------------------------------------------------------------------- #
+# web transports: new fields join the existing any([...]) list
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("kind", ["webrtc", "vapi_websocket", "retell_webcall"])
+def test_web_transport_rejects_originator_agent_id(kind: str) -> None:
+    with pytest.raises(ValueError, match=f"{kind} transport cannot set SIP fields"):
+        _agent_def(transport={"kind": kind, "originator_agent_id": "agent_1"})
+
+
+@pytest.mark.parametrize("kind", ["webrtc", "vapi_websocket", "retell_webcall"])
+def test_web_transport_rejects_originator_from_number(kind: str) -> None:
+    with pytest.raises(ValueError, match=f"{kind} transport cannot set SIP fields"):
+        _agent_def(transport={"kind": kind, "originator_from_number": "+14155551234"})
+
+
+# --------------------------------------------------------------------------- #
+# evidence provider must equal the originator; call_id_source must be
+# originator_response — Retell, and Vapi for byte-identical proof.
+# --------------------------------------------------------------------------- #
+def test_retell_originator_requires_retell_evidence() -> None:
+    with pytest.raises(ValueError, match="retell_originator_requires_retell_evidence"):
+        _agent_def(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "retell",
+                "readiness_timeout_seconds": 120,
+            },
+            provider_evidence={
+                "provider": "vapi",
+                "call_id_source": "originator_response",
+            },
+        )
+
+
+def test_retell_originator_requires_originator_response() -> None:
+    with pytest.raises(
+        ValueError, match="retell_originator_requires_originator_response"
+    ):
+        _agent_def(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "retell",
+                "readiness_timeout_seconds": 120,
+            },
+            provider_evidence={
+                "provider": "retell",
+                "call_id_source": "participant_attribute",
+                "participant_attribute": "sip.callID",
+            },
+        )
+
+
+def test_vapi_originator_requires_vapi_evidence_byte_identical() -> None:
+    # == (not match=) so an appended suffix on the templated string fails this test.
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "vapi",
+                "readiness_timeout_seconds": 120,
+            },
+            provider_evidence={
+                "provider": "retell",
+                "call_id_source": "originator_response",
+            },
+        )
+        == "vapi_originator_requires_vapi_evidence"
+    )
+
+
+def test_vapi_originator_requires_originator_response_byte_identical() -> None:
+    # == (not match=) so an appended suffix on the templated string fails this test.
+    assert (
+        _reject(
+            transport={
+                "kind": "sip_inbound",
+                "inbound_call_originator": "vapi",
+                "readiness_timeout_seconds": 120,
+            },
+            provider_evidence={
+                "provider": "vapi",
+                "call_id_source": "participant_attribute",
+                "participant_attribute": "sip.callID",
+            },
+        )
+        == "vapi_originator_requires_originator_response"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# forward compatibility: a sip_inbound+retell job without the two new fields
+# still validates (an SDK release without backend support must not break).
+# --------------------------------------------------------------------------- #
+def test_sip_inbound_retell_without_new_fields_still_validates() -> None:
+    agent = _agent_def(
+        transport={
+            "kind": "sip_inbound",
+            "inbound_call_originator": "retell",
+            "readiness_timeout_seconds": 120,
+        },
+        provider_evidence={
+            "provider": "retell",
+            "call_id_source": "originator_response",
+        },
+    )
+    assert agent.transport.originator_agent_id is None
+    assert agent.transport.originator_from_number is None
+
+
+def test_sip_inbound_retell_with_new_fields_validates() -> None:
+    agent = _agent_def(
+        transport={
+            "kind": "sip_inbound",
+            "inbound_call_originator": "retell",
+            "originator_agent_id": "agent_123",
+            "originator_from_number": "+14155550123",
+            "readiness_timeout_seconds": 120,
+        },
+        provider_evidence={
+            "provider": "retell",
+            "call_id_source": "originator_response",
+        },
+    )
+    assert agent.transport.originator_agent_id == "agent_123"
+    assert agent.transport.originator_from_number == "+14155550123"
+
+
+# --------------------------------------------------------------------------- #
+# target + SIP transport is still rejected (C1 Forbidden list)
+# --------------------------------------------------------------------------- #
+def test_target_with_sip_transport_still_rejected() -> None:
+    with pytest.raises(ValueError, match="retell_target_requires_retell_webcall"):
+        _agent_def(
+            transport={"kind": "sip_inbound", "readiness_timeout_seconds": 120},
+            target={"provider": "retell", "agent_id": "agent_healthcare"},
+        )
+
+
+# --------------------------------------------------------------------------- #
+# the Vapi originator fixture at oss/simulation-acceptance/voice_cases.py:862
+# (case_id "2.2.1") must keep validating unchanged.
+# --------------------------------------------------------------------------- #
+def test_voice_cases_vapi_originator_fixture_still_validates() -> None:
+    agent = AgentDefinition(
+        name="vapi-originating-target",
+        system_prompt="Copy the current target-agent prompt here.",
+        transport={
+            "kind": "sip_inbound",
+            "inbound_call_originator": "vapi",
+            "readiness_timeout_seconds": 120,
+        },
+        provider_evidence={
+            "provider": "vapi",
+            "call_id_source": "originator_response",
+            "poll_deadline_seconds": 90,
+        },
+    )
+    assert agent.transport.inbound_call_originator == "vapi"
+    assert agent.transport.originator_agent_id is None
+    assert agent.transport.originator_from_number is None

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-futures" },
+    { name = "retell-sdk" },
     { name = "rich" },
     { name = "rouge-score" },
     { name = "typer" },
@@ -184,6 +185,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.5,<3" },
     { name = "requests-futures", specifier = ">=1.0.0" },
+    { name = "retell-sdk", specifier = ">=5.64,<6" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rouge-score", specifier = ">=0.1.2" },
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=5.2.3,<6" },
@@ -5557,6 +5559,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/f1/34be702a69a5d272e844c98cee82351f880985cfbca0cc86378011078497/resampy-0.4.3.tar.gz", hash = "sha256:a0d1c28398f0e55994b739650afef4e3974115edbe96cd4bb81968425e916e47", size = 3080604, upload-time = "2024-03-05T20:36:08.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/b9/3b00ac340a1aab3389ebcc52c779914a44aadf7b0cb7a3bf053195735607/resampy-0.4.3-py3-none-any.whl", hash = "sha256:ad2ed64516b140a122d96704e32bc0f92b23f45419e8b8f478e5a05f83edcebd", size = 3076529, upload-time = "2024-03-05T20:36:02.439Z" },
+]
+
+[[package]]
+name = "retell-sdk"
+version = "5.64.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "cryptography" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/b9/9933ea0f9a3ff58c2ebec7c640894a53678d307ccbb19312b3ca68fd0152/retell_sdk-5.64.0.tar.gz", hash = "sha256:451328a9e50964810eb2c4e16751e0c0a30c23d45293909d5162bb59ef4f5096", size = 594887, upload-time = "2026-08-23T20:51:10.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f0/f661fe4e920ac898957664efd1f49ec6469e221f15e61be0dadfb6d3d297/retell_sdk-5.64.0-py3-none-any.whl", hash = "sha256:f9c2a23b39812a8fa20b4cbdc6d72b8aa4f37dede33e051f43c89ae0efcca58d", size = 606968, upload-time = "2026-08-23T20:51:09.304Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Ships the kit side of Retell outbound voice simulation to `dev` on its own, independent of the hosted-bundle / RL-environment work on `feat/hosted-bundle-v2-production`. Two commits cherry-picked from PR #80 (`5f5ceb75`, `93855ca9`).

Two call-site keywords that exist only on the hosted-bundle branch were dropped so the pick stands on `dev`: `variables=` and `tts_provider=` on `build_voice_simulator_prompt` (both introduced by `8cc41f70`, "fill the caller prompt from a template and drive speech from the persona"). `dev`'s prompt builder already folds the persona situation into the prompt, so behaviour on `dev` is unchanged by the drop.

Also left out, on request: the CLI/manifest-only required-env rule for the Retell originator in `endpoints/profiles.py` (`_sip_inbound_required_env`, marked parity-only in the source; no hosted code consumes it) and the matching extension of `test_required_env_parity_across_transport_kinds`. Both files are byte-identical to `dev` for that function. The hosted job carries the originator fields directly.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / CI (smoke-install pin)

## Changes

- Retell call originator so a customer's outbound Retell agent can dial the simulator over SIP; originator lifecycle made provider-neutral; Retell get-call polled to a terminal status for evidence; hosted voice params that `run_voice_simulation` cannot bind are dropped.
- Multi-scenario phone runs reuse one leased LiveKit room: drain before every case, refuse to dial into an occupied room, verify the caller against the originator's number after readiness, record the verification in case metadata, write the cleanup status last so a failed teardown is never reported clean.
- CI: pin the clean-install smoke job to the shipped `livekit-agents` 1.5.17 and plugins; patch the generator builder where it resolves (`livekit_models`).

## Testing

- `uv sync --frozen --extra livekit`, then pytest on `tests/test_call_originator_factory.py`, `tests/test_retell_endpoint.py`, `tests/test_retell_transport_validation.py`, `tests/test_retell_evidence.py`, `tests/runtime/test_livekit_engine.py`, `tests/runtime/test_voice_environment.py`, `tests/test_acceptance_regressions.py`: 268 passed.
- Exercised end to end over SIP and webcall from the platform on the source branch.

## Bundled global LiveKit engine changes

Requested by review: this PR also carries reliability changes to the shared
LiveKit engine (`simulation/engines/livekit.py`) that affect every LiveKit voice
run, not only Retell originator runs. They are documented here so they can be
assessed as intentional parts of this release.

Why they ship with the Retell work rather than as their own PR: they are one
voice-reliability change set, interleaved inside the engine's
`_run_single_test_case` run loop with the originator/leased-room feature, and
the files are shared. Splitting them would be run-loop surgery on the path
already proven on the dev box, and would not buy independent rollback (both
change sets edit the same loop). Reverting this PR reverts all of it together.
Future engine-only reliability changes will land in their own PR.

Each behavior, what it changes, and its covering tests in
`tests/runtime/test_livekit_engine.py` (all part of the 268 passing above):

1. **Caller identity propagation** — `_simulator_participant_identity`: the
   simulator joins with a stable identity carrying the fixture phone for
   repository agents, and keeps the legacy identity shape when no valid phone is
   present. Tests: `test_simulator_identity_carries_fixture_phone_for_repository_agents`,
   `test_simulator_identity_preserves_legacy_shape_without_valid_phone`.
2. **Audio-track selection** — `_find_target_audio` / `_wait_for_target_audio`:
   the simulator selects and records the target's audio by explicit participant
   identity and ignores a same-agent background track. Tests:
   `test_target_audio_selection_uses_explicit_identity`,
   `test_target_audio_selection_ignores_background_track_from_same_agent`,
   `test_simulator_subscribes_to_sip_participant_audio`.
3. **Recording fallback and stereo mix** — `_attach_recordings` /
   `_collapse_recordings`: recordings attach by explicit paths, fall back to all
   target tracks when identity is ambiguous, and the stereo mix interleaves,
   zero-pads, and sums each side. Tests: `test_attach_recordings_falls_back_to_all_target_tracks`,
   `test_attach_recordings_uses_unambiguous_simulator_identity_fallback`,
   `test_recording_mix_uses_only_explicit_paths`, the five `test_stereo_mix_*`,
   `test_room_recorder_token_is_hidden_subscribe_only`.
4. **Background audio (opt-in, off by default)** — `_maybe_start_background_audio`
   / `_stop_background_audio`: mixes caller-side ambient noise under the
   simulated caller only when `HARNESS_BACKGROUND_NOISE` names a source.
   Rollout: inert in production unless that env var is set, so the default path
   is unchanged. Test: `test_target_audio_selection_ignores_background_track_from_same_agent`
   (the background track never pollutes target-audio selection).
5. **Farewell-loop termination** — `_is_closing_only` / `_wait_for_closing_loop`:
   a run that has decayed into farewell-only turns is recognised as a completed
   call rather than a stall. Tests: `test_farewell_only_turns_are_recognised_as_a_closing_loop`,
   `test_a_turn_carrying_content_is_not_a_closing`,
   `test_closing_loop_reports_the_call_as_completed`.
6. **TTS-silence classification** — `_wait_for_conversation_silence` /
   `_caller_never_spoke`: distinguishes a genuine silence stall from a caller
   whose turns were synthesized but untimed, naming the synthesis instead of
   falsely reporting a stall. Tests: `test_silence_with_untimed_caller_turns_names_the_synthesis`,
   `test_silence_with_audible_caller_turns_still_reports_a_stall`, the
   `test_conversation_silence_backstop_*` set.
7. **Terminal-exchange recovery** — `_has_natural_terminal_exchange`: a call that
   reached a natural terminal exchange before an agent-first silence is reported
   completed, not failed. Test: `test_agent_first_silence_after_terminal_exchange_is_completed`.
8. **Agent-first silence timeout** — `_wait_for_agent_first_silence` /
   `_wait_for_conversation_never_started`: a global timeout for an agent-first
   call where the agent never speaks, parked once real turns exist. Tests:
   `test_dead_call_with_no_turns_ends_as_no_conversation`,
   `test_no_conversation_guard_parks_once_turns_exist`,
   `test_agent_first_silence_after_terminal_exchange_is_completed`.
9. **Simulator setup artifacts** — `_record_simulator_setup`: writes the
   simulator's resolved persona, instructions, and LLM/STT/TTS config into the
   per-case recording directory as a diagnostic artifact. Rollout: a pure file
   write, no effect on call flow. Covered via the recording case-directory tests
   (`test_recording_case_directory_is_used_without_repeating_run_and_case`).

Rollout evidence: all nine are exercised by the engine test suite (part of the
268 passing) and ran end to end over SIP and webcall on the dev box, across both
call directions (a dial-out run and a 9-case Retell-originator run).

## Related Issues

Companion platform PR: https://github.com/future-agi/future-agi/pull/2602
Source PR on the hosted-bundle base: #80.


