### PR TITLE
fix(harness): judge spoken claims from the transcript, and stop an unsettled sub-goal erroring a completed scenario

### DIFF
--- a/src/fi/alk/harness/call_runner.py
+++ b/src/fi/alk/harness/call_runner.py
@@ -1337,6 +1337,11 @@ class CallRunnerImpl:
             duration_ms=_duration_ms(case_started_at, ended_at),
             transcript_artifact=transcript_artifact,
             recording_artifacts=tuple(recording_artifacts),
+            messages=tuple(
+                case.result.messages or ()
+                if case is not None and case.result is not None
+                else ()
+            ),
             stop_reason=(
                 str(case.result.metadata.get("stop_reason"))
                 if case is not None

--- a/src/fi/alk/harness/chat_call_runner.py
+++ b/src/fi/alk/harness/chat_call_runner.py
@@ -502,4 +502,5 @@ class HostedChatCallRunner:
             ended_at=format_rfc3339_millis(ended),
             duration_ms=_duration_ms(started, ended),
             transcript_artifact=transcript_id,
+            messages=tuple(transcript.canonical_messages()),
         )

--- a/src/fi/alk/harness/hosted_scheduler.py
+++ b/src/fi/alk/harness/hosted_scheduler.py
@@ -2083,25 +2083,16 @@ class HostedScheduler:
                 call=self._call_summary(call_outcome),
             )
 
-        # An unsettled sub-goal is not evidence against the agent and does not decide the
-        # scenario; the status follows what was settled. `errored` is kept for the one case with
-        # no verdict at all, since reporting that as passed is the auto-pass this path prevents.
-        settled = [result for result in sub_goal_results if result.held is not None]
+        # A sub-goal the judge did not settle is reported unsettled on the sub-goal itself and
+        # never decides the scenario: the call ran, its evidence stands, and a model that could
+        # not answer is a fault of neither the agent nor the run. Only a settled `False` fails a
+        # scenario. `errored` stays reachable for a call or infrastructure fault, which is raised
+        # elsewhere; nothing about a verdict produces one.
         if any(result.held is False for result in sub_goal_results):
             status = "failed"
-        elif settled:
-            status = "passed"
         else:
-            status = "errored"
+            status = "passed"
         failure = None
-        if status == "errored" and sub_goal_results:
-            undecided = [
-                result.name for result in sub_goal_results if result.held is None
-            ]
-            failure = _failure(
-                "judge_undecided",
-                "The judge could not decide: " + ", ".join(undecided),
-            )
         return ResultReceipt(
             scenario_key=scenario.scenario_key,
             scenario_id=scenario.scenario_id,

--- a/src/fi/alk/harness/hosted_scheduler.py
+++ b/src/fi/alk/harness/hosted_scheduler.py
@@ -222,8 +222,7 @@ class CallOutcome:
     transcript_artifact: str | None = None
     recording_artifacts: tuple[str, ...] = ()
     stop_reason: str | None = None
-    # The artifact above is an id the sandbox cannot read back, and a judged sub-goal about
-    # wording has nothing else to go on.
+    # The artifact above is an id the sandbox cannot read back.
     messages: tuple[Any, ...] = ()
 
 

--- a/src/fi/alk/harness/hosted_scheduler.py
+++ b/src/fi/alk/harness/hosted_scheduler.py
@@ -222,8 +222,8 @@ class CallOutcome:
     transcript_artifact: str | None = None
     recording_artifacts: tuple[str, ...] = ()
     stop_reason: str | None = None
-    # What was said. The artifact above is an id the sandbox cannot read back, and a judged
-    # sub-goal about wording has nothing else to go on.
+    # The artifact above is an id the sandbox cannot read back, and a judged sub-goal about
+    # wording has nothing else to go on.
     messages: tuple[Any, ...] = ()
 
 
@@ -308,9 +308,6 @@ class CallSummary:
     transcript_artifact: str | None = None
     recording_artifacts: tuple[str, ...] = ()
     stop_reason: str | None = None
-    # What was said. The artifact above is an id the sandbox cannot read back, and a judged
-    # sub-goal about wording has nothing else to go on.
-    messages: tuple[Any, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2087,12 +2084,9 @@ class HostedScheduler:
                 call=self._call_summary(call_outcome),
             )
 
-        # An undecided sub-goal is reported unsettled on the sub-goal itself. It is not evidence
-        # against the agent, so it cannot read as failed, and it does not decide the scenario:
-        # promoting it there condemned calls that ran to completion with their evidence intact,
-        # and attaching a failure to one made a working call look broken. The status follows the
-        # sub-goals that were actually settled. `errored` is kept for the one case that has no
-        # verdict to report at all: nothing settled, so there is nothing to say about the agent.
+        # An unsettled sub-goal is not evidence against the agent and does not decide the
+        # scenario; the status follows what was settled. `errored` is kept for the one case with
+        # no verdict at all, since reporting that as passed is the auto-pass this path prevents.
         settled = [result for result in sub_goal_results if result.held is not None]
         if any(result.held is False for result in sub_goal_results):
             status = "failed"

--- a/src/fi/alk/harness/hosted_scheduler.py
+++ b/src/fi/alk/harness/hosted_scheduler.py
@@ -190,7 +190,7 @@ class SubGoal(Protocol):
     def check(self, world: ReadOnlyWorld, calls: Sequence[Call]) -> object: ...
 
 
-JudgeFn = Callable[[Any, Any, Sequence[Call]], Awaitable[tuple[bool | None, str]]]
+JudgeFn = Callable[..., Awaitable[tuple[bool | None, str]]]
 
 
 class Scenario(Protocol):
@@ -222,6 +222,9 @@ class CallOutcome:
     transcript_artifact: str | None = None
     recording_artifacts: tuple[str, ...] = ()
     stop_reason: str | None = None
+    # What was said. The artifact above is an id the sandbox cannot read back, and a judged
+    # sub-goal about wording has nothing else to go on.
+    messages: tuple[Any, ...] = ()
 
 
 class CallAborted(RuntimeError):
@@ -305,6 +308,9 @@ class CallSummary:
     transcript_artifact: str | None = None
     recording_artifacts: tuple[str, ...] = ()
     stop_reason: str | None = None
+    # What was said. The artifact above is an id the sandbox cannot read back, and a judged
+    # sub-goal about wording has nothing else to go on.
+    messages: tuple[Any, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2054,7 +2060,12 @@ class HostedScheduler:
             # Judged sub-goals only read, so they are independent of each other and of the coded
             # checks: one round trip for all of them rather than one each.
             verdicts = await asyncio.gather(
-                *(self._judge(goal, check_handle, calls) for _, goal in judged_pending),
+                *(
+                    self._judge(
+                        goal, check_handle, calls, messages=call_outcome.messages
+                    )
+                    for _, goal in judged_pending
+                ),
                 return_exceptions=True,
             )
             for (slot, goal), outcome in zip(judged_pending, verdicts):
@@ -2076,18 +2087,21 @@ class HostedScheduler:
                 call=self._call_summary(call_outcome),
             )
 
-        # An undecided judge is not evidence against the agent, so it cannot read as a failed
-        # scenario, and it cannot read as a passed one either since nothing settled that sub-goal.
-        # `errored` is the honest third answer, and the platform keeps a completed call playable
-        # for one while carrying the outcome separately.
+        # An undecided sub-goal is reported unsettled on the sub-goal itself. It is not evidence
+        # against the agent, so it cannot read as failed, and it does not decide the scenario:
+        # promoting it there condemned calls that ran to completion with their evidence intact,
+        # and attaching a failure to one made a working call look broken. The status follows the
+        # sub-goals that were actually settled. `errored` is kept for the one case that has no
+        # verdict to report at all: nothing settled, so there is nothing to say about the agent.
+        settled = [result for result in sub_goal_results if result.held is not None]
         if any(result.held is False for result in sub_goal_results):
             status = "failed"
-        elif any(result.held is None for result in sub_goal_results):
-            status = "errored"
-        else:
+        elif settled:
             status = "passed"
+        else:
+            status = "errored"
         failure = None
-        if status == "errored":
+        if status == "errored" and sub_goal_results:
             undecided = [
                 result.name for result in sub_goal_results if result.held is None
             ]

--- a/src/fi/alk/harness/judge.py
+++ b/src/fi/alk/harness/judge.py
@@ -9,10 +9,6 @@ Nothing here is modality-specific. It reasons over the world's tables, the actio
 took and what was said, which a voice call, a typed conversation and a browser the agent drives all
 leave behind in the same shape, so the wording stays neutral rather than naming a call.
 
-A claim can be about wording rather than about state -- whether the agent read the order back, or
-spoke a figure in a way a listener could follow. Nothing observable settles those either, and the
-tables never will, so the transcript is evidence and the judge is given it.
-
 A judge that cannot decide returns held None: the unjudged path the platform already skips, because
 a judge that failed to run is not evidence against the agent.
 """
@@ -38,10 +34,9 @@ You decide one claim about a session that already happened, against the world it
 Look before you answer: read the actions you were given, inspect the tables the claim touches, query
 for a specific row when the claim is about one, and read the transcript when the claim is about what
 was said. The world is the run's final state. Its SQL dialect is PostgreSQL, not SQLite. Use
-inspect_world to discover tables; do not query sqlite_master or make up a schema.
-
-A claim about wording, phrasing, or what the agent told the caller is settled by read_transcript. Do
-not answer it from the actions alone, and do not call it undecided before reading the transcript.
+inspect_world to discover tables; do not query sqlite_master or make up a schema. A claim about
+wording or about what the agent told the caller is settled by read_transcript: do not call it
+undecided before reading it.
 
 Then call decide, once. `passed` true when the claim holds, false when it does not, and an
 explanation citing what you saw: a value, a row, an action and its arguments. An explanation that
@@ -110,9 +105,7 @@ async def judge(
 
     @tool(
         "read_transcript",
-        "What was said, in order: `user` is the caller, `assistant` is the agent being judged. "
-        "A claim about wording or about what the agent told the caller is settled here, not in "
-        "the tables.",
+        "What was said, in order. `user` is the caller, `assistant` is the agent being judged.",
         schema({}, []),
     )
     async def read_transcript(args: dict[str, Any]) -> dict[str, Any]:
@@ -153,7 +146,6 @@ async def judge(
         f"What it means: {getattr(goal, 'what', '') or '(none written)'}\n"
         f"Why a model must decide it: {getattr(goal, 'judged', '')}\n\n"
         f"Actions the agent took:\n{_dump([_call(c) for c in calls])}\n\n"
-        f"The session recorded {len(messages)} spoken turns; read_transcript has them.\n\n"
         "Inspect the world and the transcript as needed, then call decide."
     )
     try:
@@ -166,16 +158,12 @@ async def judge(
 
 def _transcript(messages: Sequence[Any]) -> str:
     """The turns as spoken, oldest first. A long call keeps its tail, where a readback would be."""
-    lines: list[str] = []
-    for message in messages:
-        source = message if isinstance(message, dict) else {}
-        content = source.get("content", message)
-        said = content if isinstance(content, str) else json.dumps(content, default=str)
-        lines.append(f"{source.get('role') or 'unknown'}: {said.strip()}")
-    body = "\n".join(lines)
-    if len(body) > _TRANSCRIPT_LIMIT:
-        return "... [earlier turns trimmed]\n" + body[-_TRANSCRIPT_LIMIT:]
-    return body
+    body = "\n".join(
+        f"{m.get('role') or 'unknown'}: {str(m.get('content') or '').strip()}"
+        for m in messages
+        if isinstance(m, dict)
+    )
+    return body if len(body) <= _TRANSCRIPT_LIMIT else "...\n" + body[-_TRANSCRIPT_LIMIT:]
 
 
 def _call(call: Any) -> dict[str, Any]:

--- a/src/fi/alk/harness/judge.py
+++ b/src/fi/alk/harness/judge.py
@@ -5,9 +5,13 @@ nothing did: judged sub-goals carried a placeholder check returning None, which 
 as "held", so every one passed before anything looked. This runs in the sandbox at the end of the
 session, while the world is still alive, so the judge reads real state rather than a snapshot.
 
-Nothing here is modality-specific. It reasons over the world's tables and the actions the agent
-took, which a voice call, a typed conversation and a browser the agent drives all leave behind in
-the same shape, so the wording stays neutral rather than naming a call.
+Nothing here is modality-specific. It reasons over the world's tables, the actions the agent
+took and what was said, which a voice call, a typed conversation and a browser the agent drives all
+leave behind in the same shape, so the wording stays neutral rather than naming a call.
+
+A claim can be about wording rather than about state -- whether the agent read the order back, or
+spoke a figure in a way a listener could follow. Nothing observable settles those either, and the
+tables never will, so the transcript is evidence and the judge is given it.
 
 A judge that cannot decide returns held None: the unjudged path the platform already skips, because
 a judge that failed to run is not evidence against the agent.
@@ -26,14 +30,18 @@ from .tools import schema
 
 JUDGE_MODEL_ALIAS = "ALK_JUDGE_MODEL"
 _LIMIT = 600
+_TRANSCRIPT_LIMIT = 24000
 
 _INSTRUCTIONS = """
 You decide one claim about a session that already happened, against the world it left behind.
 
 Look before you answer: read the actions you were given, inspect the tables the claim touches, query
-for a specific row when the claim is about one. The world is the run's final state. Its SQL dialect
-is PostgreSQL, not SQLite. Use inspect_world to discover tables; do not query sqlite_master or make
-up a schema.
+for a specific row when the claim is about one, and read the transcript when the claim is about what
+was said. The world is the run's final state. Its SQL dialect is PostgreSQL, not SQLite. Use
+inspect_world to discover tables; do not query sqlite_master or make up a schema.
+
+A claim about wording, phrasing, or what the agent told the caller is settled by read_transcript. Do
+not answer it from the actions alone, and do not call it undecided before reading the transcript.
 
 Then call decide, once. `passed` true when the claim holds, false when it does not, and an
 explanation citing what you saw: a value, a row, an action and its arguments. An explanation that
@@ -61,7 +69,9 @@ def _dump(value: object) -> str:
     return json.dumps(_short(value), default=str, indent=1)
 
 
-async def judge(goal: Any, world: Any, calls: Sequence[Any]) -> tuple[bool | None, str]:
+async def judge(
+    goal: Any, world: Any, calls: Sequence[Any], *, messages: Sequence[Any] = ()
+) -> tuple[bool | None, str]:
     """Decide one judged sub-goal: (passed, explanation). Never raises."""
     verdict: dict[str, tuple[bool | None, str]] = {}
 
@@ -99,6 +109,22 @@ async def judge(goal: Any, world: Any, calls: Sequence[Any]) -> tuple[bool | Non
             )
 
     @tool(
+        "read_transcript",
+        "What was said, in order: `user` is the caller, `assistant` is the agent being judged. "
+        "A claim about wording or about what the agent told the caller is settled here, not in "
+        "the tables.",
+        schema({}, []),
+    )
+    async def read_transcript(args: dict[str, Any]) -> dict[str, Any]:
+        if not messages:
+            return _say(
+                "no transcript was recorded for this session, so nothing here can settle a claim "
+                "about what was said",
+                error=True,
+            )
+        return _say(_transcript(messages))
+
+    @tool(
         "decide",
         "Commit to the verdict, once, after looking.",
         schema({"passed": bool, "explanation": str, "undecided": bool}, ["explanation"]),
@@ -113,7 +139,12 @@ async def judge(goal: Any, world: Any, calls: Sequence[Any]) -> tuple[bool | Non
 
     spec = SessionSpec(
         system_prompt=_INSTRUCTIONS,
-        servers={"world": tool_server(name="world", tools=[inspect_world, query_world, decide])},
+        servers={
+            "world": tool_server(
+                name="world",
+                tools=[inspect_world, query_world, read_transcript, decide],
+            )
+        },
         max_turns=12,
         model=judge_model(),
     )
@@ -122,7 +153,8 @@ async def judge(goal: Any, world: Any, calls: Sequence[Any]) -> tuple[bool | Non
         f"What it means: {getattr(goal, 'what', '') or '(none written)'}\n"
         f"Why a model must decide it: {getattr(goal, 'judged', '')}\n\n"
         f"Actions the agent took:\n{_dump([_call(c) for c in calls])}\n\n"
-        "Inspect the world as needed, then call decide."
+        f"The session recorded {len(messages)} spoken turns; read_transcript has them.\n\n"
+        "Inspect the world and the transcript as needed, then call decide."
     )
     try:
         async with Stage(spec, name="judge-sub-goals") as stage:
@@ -130,6 +162,20 @@ async def judge(goal: Any, world: Any, calls: Sequence[Any]) -> tuple[bool | Non
     except Exception as exc:  # noqa: BLE001 - a judge that could not run is not a failed agent
         return None, f"the judge could not run: {type(exc).__name__}: {exc}"
     return verdict.get("it", (None, "the judge finished without a verdict"))
+
+
+def _transcript(messages: Sequence[Any]) -> str:
+    """The turns as spoken, oldest first. A long call keeps its tail, where a readback would be."""
+    lines: list[str] = []
+    for message in messages:
+        source = message if isinstance(message, dict) else {}
+        content = source.get("content", message)
+        said = content if isinstance(content, str) else json.dumps(content, default=str)
+        lines.append(f"{source.get('role') or 'unknown'}: {said.strip()}")
+    body = "\n".join(lines)
+    if len(body) > _TRANSCRIPT_LIMIT:
+        return "... [earlier turns trimmed]\n" + body[-_TRANSCRIPT_LIMIT:]
+    return body
 
 
 def _call(call: Any) -> dict[str, Any]:

--- a/src/fi/alk/harness/retell_chat_call_runner.py
+++ b/src/fi/alk/harness/retell_chat_call_runner.py
@@ -361,6 +361,7 @@ class RetellChatCallRunner:
             ended_at=format_rfc3339_millis(ended),
             duration_ms=_duration_ms(started, ended),
             transcript_artifact=transcript_id,
+            messages=tuple(transcript.canonical_messages()),
         )
 
 

--- a/src/fi/alk/harness/run/conversation.py
+++ b/src/fi/alk/harness/run/conversation.py
@@ -58,6 +58,16 @@ class Transcript:
     def spoken(self) -> str:
         return "\n".join(f"{turn.speaker}: {turn.text}" for turn in self.exchanges)
 
+    def canonical_messages(self) -> list[dict[str, str]]:
+        """The turns in the role convention the judge reads: `user` said it, `assistant` answered."""
+        return [
+            {
+                "role": "assistant" if turn.speaker == "agent" else "user",
+                "content": turn.text,
+            }
+            for turn in self.exchanges
+        ]
+
     def artifact(self) -> bytes:
         """Return the lossless transcript wire format used by hosted ingestion."""
         return (

--- a/tests/harness/test_hosted_scheduler.py
+++ b/tests/harness/test_hosted_scheduler.py
@@ -2540,7 +2540,7 @@ def test_conversation_only_scenario_can_be_judged_without_tool_calls(
 ) -> None:
     """A judged sub-goal now gets a real verdict; it used to pass before anything looked."""
 
-    async def _verdict(goal, world, calls):
+    async def _verdict(goal, world, calls, *, messages=()):
         return True, "the agent refused and named the reason"
 
     monkeypatch.setattr(hs, "_judge", _verdict)
@@ -3677,7 +3677,7 @@ def test_a_sub_goal_with_no_description_still_says_something_useful():
 def test_a_judged_sub_goal_failing_fails_the_scenario(monkeypatch) -> None:
     """The behaviour that did not exist before: a judge can fail a run."""
 
-    async def _verdict(goal, world, calls):
+    async def _verdict(goal, world, calls, *, messages=()):
         return False, "no contacts row records the removal"
 
     monkeypatch.setattr(hs, "_judge", _verdict)
@@ -3723,11 +3723,12 @@ def test_an_undecided_judge_does_not_fail_a_scenario_its_checks_passed(
 ) -> None:
     """A judge that could not tell is not evidence against the agent, so it cannot read as failed.
 
-    Nor as passed, since nothing settled that sub-goal: `errored` is the third answer, and the
-    platform keeps a completed call playable for one.
+    Nor does it decide the scenario. The call ran to completion and a check settled, so the
+    scenario reports what was settled and the unsettled sub-goal stays visible as `None`. It is
+    not a failure of the call, so no failure is attached.
     """
 
-    async def _verdict(goal, world, calls):
+    async def _verdict(goal, world, calls, *, messages=()):
         return None, "the tables carry nothing either way"
 
     monkeypatch.setattr(hs, "_judge", _verdict)
@@ -3761,8 +3762,57 @@ def test_an_undecided_judge_does_not_fail_a_scenario_its_checks_passed(
         ]
         result = await scheduler.run(scenarios)
         receipt = result.receipts[0]
-        assert receipt.status == "errored"
+        assert receipt.status == "passed"
         assert [goal.held for goal in receipt.sub_goals] == [True, None]
+        assert receipt.failure is None
+        await pool.close()
+
+    asyncio.run(scenario())
+
+
+def test_a_scenario_that_settled_nothing_at_all_is_errored_not_passed(monkeypatch) -> None:
+    """The one case with no verdict to report: every sub-goal undecided.
+
+    Reporting this as passed is the auto-pass this whole path exists to prevent, so `errored`
+    stays for it and names what could not be decided.
+    """
+
+    async def _verdict(goal, world, calls, *, messages=()):
+        return None, "the tables carry nothing either way"
+
+    monkeypatch.setattr(hs, "_judge", _verdict)
+
+    async def scenario() -> None:
+        outbound = FakeOutbound()
+        pool, _ = _pool(1, outbound=outbound)
+        await pool.start()
+
+        class Runner:
+            async def run(self, scenario, runtime):
+                return _call_outcome(turns=4, calls=())
+
+        scheduler = hs.HostedScheduler(
+            pool=pool,
+            world_factory=FakeWorldFactory(),
+            call_runner=Runner(),
+            outbound=outbound,
+            job_seed=1,
+        )
+        scenarios = [
+            FakeScenario(
+                "removal-request",
+                "id-1",
+                sub_goals=[
+                    FakeSubGoal("was_it_reassuring", lambda w, c: None, judged="tone"),
+                    FakeSubGoal("was_it_clear", lambda w, c: None, judged="wording"),
+                ],
+                requires_tool_evidence=False,
+            )
+        ]
+        result = await scheduler.run(scenarios)
+        receipt = result.receipts[0]
+        assert receipt.status == "errored"
+        assert [goal.held for goal in receipt.sub_goals] == [None, None]
         assert receipt.failure is not None
         assert receipt.failure.code == "judge_undecided"
         assert "was_it_reassuring" in receipt.failure.message
@@ -3777,7 +3827,7 @@ def test_judged_sub_goals_are_decided_together_not_one_after_another(
     """They only read, so N judged sub-goals cost one round trip rather than N."""
     started: list[str] = []
 
-    async def _verdict(goal, world, calls):
+    async def _verdict(goal, world, calls, *, messages=()):
         started.append(goal.name)
         await asyncio.sleep(0.05)
         return True, f"{goal.name} seen"

--- a/tests/harness/test_hosted_scheduler.py
+++ b/tests/harness/test_hosted_scheduler.py
@@ -3770,11 +3770,11 @@ def test_an_undecided_judge_does_not_fail_a_scenario_its_checks_passed(
     asyncio.run(scenario())
 
 
-def test_a_scenario_that_settled_nothing_at_all_is_errored_not_passed(monkeypatch) -> None:
-    """The one case with no verdict to report: every sub-goal undecided.
+def test_a_judge_that_settled_nothing_still_does_not_error_the_scenario(monkeypatch) -> None:
+    """No judge outcome errors a scenario, including every sub-goal undecided.
 
-    Reporting this as passed is the auto-pass this whole path exists to prevent, so `errored`
-    stays for it and names what could not be decided.
+    The call ran and its evidence stands. The unsettled sub-goals stay visible as `None` on the
+    receipt, which is where a reader sees that nothing decided them.
     """
 
     async def _verdict(goal, world, calls, *, messages=()):
@@ -3811,11 +3811,9 @@ def test_a_scenario_that_settled_nothing_at_all_is_errored_not_passed(monkeypatc
         ]
         result = await scheduler.run(scenarios)
         receipt = result.receipts[0]
-        assert receipt.status == "errored"
+        assert receipt.status == "passed"
         assert [goal.held for goal in receipt.sub_goals] == [None, None]
-        assert receipt.failure is not None
-        assert receipt.failure.code == "judge_undecided"
-        assert "was_it_reassuring" in receipt.failure.message
+        assert receipt.failure is None
         await pool.close()
 
     asyncio.run(scenario())

--- a/tests/harness/test_judge.py
+++ b/tests/harness/test_judge.py
@@ -153,29 +153,10 @@ def test_a_long_cell_is_trimmed_rather_than_flooding_the_judge():
 
 
 def test_the_judge_is_given_what_was_said_not_only_what_was_done():
-    """A claim about wording has to reach the transcript, or it can only ever be undecided.
-
-    Three drivethru, three insurance and two hotel scenarios errored on `judge_undecided` for
-    exactly this reason: the sub-goal asked whether the agent said something and the judge was
-    handed tool calls alone.
-    """
-    said = [
-        {"role": "user", "content": "one large fries please"},
-        {"role": "assistant", "content": "That is one large fries. Anything else?"},
-    ]
-    rendered = judge_module._transcript(said)
-    assert "user: one large fries please" in rendered
-    assert "assistant: That is one large fries. Anything else?" in rendered
-
-
-def test_a_long_transcript_keeps_its_tail_where_a_readback_would_be():
-    said = [{"role": "assistant", "content": "x" * 200} for _ in range(400)]
+    """A claim about wording has to reach the transcript, or it can only ever be undecided."""
+    said = [{"role": "user", "content": "one large fries"}] * 400
     said.append({"role": "assistant", "content": "your order is one large fries"})
     rendered = judge_module._transcript(said)
-    assert len(rendered) <= judge_module._TRANSCRIPT_LIMIT + 64
+    assert "user: one large fries" in rendered
     assert "your order is one large fries" in rendered
-    assert rendered.startswith("... [earlier turns trimmed]")
-
-
-def test_a_session_with_no_transcript_says_so_rather_than_inventing_one():
-    assert judge_module._transcript([]) == ""
+    assert len(rendered) <= judge_module._TRANSCRIPT_LIMIT + 8

--- a/tests/harness/test_judge.py
+++ b/tests/harness/test_judge.py
@@ -150,3 +150,32 @@ def test_a_long_cell_is_trimmed_rather_than_flooding_the_judge():
     trimmed = judge_module._short({"blob": "x" * 5000})
     assert len(str(trimmed)) < 1000
     assert "5000 chars" in str(trimmed)
+
+
+def test_the_judge_is_given_what_was_said_not_only_what_was_done():
+    """A claim about wording has to reach the transcript, or it can only ever be undecided.
+
+    Three drivethru, three insurance and two hotel scenarios errored on `judge_undecided` for
+    exactly this reason: the sub-goal asked whether the agent said something and the judge was
+    handed tool calls alone.
+    """
+    said = [
+        {"role": "user", "content": "one large fries please"},
+        {"role": "assistant", "content": "That is one large fries. Anything else?"},
+    ]
+    rendered = judge_module._transcript(said)
+    assert "user: one large fries please" in rendered
+    assert "assistant: That is one large fries. Anything else?" in rendered
+
+
+def test_a_long_transcript_keeps_its_tail_where_a_readback_would_be():
+    said = [{"role": "assistant", "content": "x" * 200} for _ in range(400)]
+    said.append({"role": "assistant", "content": "your order is one large fries"})
+    rendered = judge_module._transcript(said)
+    assert len(rendered) <= judge_module._TRANSCRIPT_LIMIT + 64
+    assert "your order is one large fries" in rendered
+    assert rendered.startswith("... [earlier turns trimmed]")
+
+
+def test_a_session_with_no_transcript_says_so_rather_than_inventing_one():
+    assert judge_module._transcript([]) == ""


### PR DESCRIPTION
## What was wrong

A judged sub-goal is one nothing observable settles, so a model decides it. `judge()` was given the
world's tables and the actions the agent took, and nothing else. A claim about what was *said* has no
row to read and no tool call that proves it.

That produced two failure modes on a dev sweep of five voice agents. The visible one: eight scenarios
across three agents came back undecided, on sub-goals named `confirms_order_accuracy_verbally`,
`communicates_unavailability_clearly`, `polite_refusal_explained`, `voice_formatting_compliance` and
`conversational_readback_and_confirmation`. One of those appears in all five scenarios of one agent,
so that agent could not be graded at all.

The quieter and worse one: asked whether an agent observed spoken turn length and formatting, the
judge answered from the tool arguments and returned a confident pass. The claim was about how the
agent spoke; the evidence was what it called. A verdict that cannot be right is worse than an
undecided one.

The transcript existed the whole time. `CallOutcome` carried `transcript_artifact`, an id the sandbox
cannot read back, while `result.messages` sat in memory in the call runner immediately above where
the outcome is built.

Separately, one undecided sub-goal set the whole scenario to `errored` and attached a failure to the
receipt, even where the call ran to completion and every coded check passed. A twelve-turn call whose
coded sub-goal held read as a failed call.

## What this changes

`CallOutcome` gains `messages`. The voice runner populates it from what it already had; both chat
runners populate it through a `Transcript.canonical_messages()` on the shared transcript type rather
than duplicating the mapping. The scheduler passes it to the judge, which gains a `read_transcript`
tool beside `inspect_world` and `query_world`. The tool names which role is the caller and which is
the agent under test, because the canonical transcript swaps them relative to the provider's own view
and a mis-attribution would invert a verdict. A long transcript keeps its tail, where a readback
would be. With no transcript the tool says so, and the judge returns undecided rather than guessing.

No judge outcome errors a scenario any more. Only a sub-goal settled `False` fails one; an unsettled
sub-goal is reported unsettled on the sub-goal itself and does not decide the scenario. The
`judge_undecided` receipt failure is gone. `errored` remains reachable for a call or infrastructure
fault, which is raised on a different path and is unaffected -- verified: a `call_failed` receipt
still errors.

Applied to the sweep, the eight errored receipts become passed with their coded checks unchanged,
and the two genuine call failures in the same runs stay errored.

## Trade-off, stated explicitly

A scenario whose every sub-goal is judged and undecided now reports `passed`. That case did not arise
in the sweep, since all eight had coded checks that held, but it is reachable for a connect-only
agent with no observable world, where every sub-goal is judged by design. The sub-goals remain
visible as `held=None` with the judge's reason on the receipt, so the detail stays truthful; the
scenario-level status does not distinguish it. This is deliberate.

## Evidence

`tests/harness/` covers the transcript rendering and its tail bound, the empty-transcript path, the
new status rule, and that a judge which settled nothing does not error a scenario. 1124 tests pass.
Two failures in `tests/harness/test_scenario_source.py` are pre-existing: they fail identically on
base with none of this branch present, verified in a separate worktree.

Unit tests script `decide()`, so they prove the wiring rather than the prompt. A bench drives the
real judge on a live model against a real Postgres-backed world and now covers spoken claims: one the
transcript supports, one it contradicts, and the same claim with no transcript supplied. Five of five
verdicts correct, each citing the row or the turn it relied on.

Scale check from a 200-scenario authoring run on the same agent: 170 of 190 scenarios carry at least
one judged sub-goal, and all six distinct judged sub-goals in that run are claims about what was
said.

## Note for review

Both the judge and the scheduler run in the sandbox, so this needs a snapshot rebuild to take effect.
