### PR TITLE
fix(harness): register a LiveKit CLI agent that ships no Dockerfile

### DIFF
--- a/src/fi/alk/harness/bundle_author_v2.py
+++ b/src/fi/alk/harness/bundle_author_v2.py
@@ -906,17 +906,12 @@ def _dockerfile_run(root: Path) -> list[str] | None:
     return argv
 
 
-# LiveKit's CLI is a subcommand app: `agent.py` with no subcommand prints usage and exits, so the
-# worker never registers. Anything that already starts one is left alone.
+# LiveKit's CLI needs a subcommand: `agent.py` alone prints usage and exits without registering.
 _LIVEKIT_WORKER_SUBCOMMANDS = frozenset({"start", "dev", "connect", "console"})
 
 
 def _hands_off_to_livekit_cli(root: Path, entry: str) -> bool:
-    """Whether the entry script ends in `cli.run_app`, which is what needs the subcommand.
-
-    A repository can also start its worker itself, and appending a subcommand to one of those
-    would break it, so this reads the entry rather than assuming every LiveKit agent is a CLI app.
-    """
+    """Whether the entry delegates to LiveKit's CLI. An agent that runs its own worker must not."""
     path = root / entry
     if not path.is_file():
         return False
@@ -1307,8 +1302,8 @@ def resolve_environment_plan(
                     log_marker="registered worker", timeout_seconds=180
                 )
             }
-            # A Dockerfile CMD normally carries the subcommand. A repository without one gets a
-            # bare `python agent.py`, which exits on its usage banner before it can register.
+            # Only a Dockerfile CMD carries the subcommand today, so a repository without one
+            # starts `agent.py` bare and never reaches the registration this check waits for.
             if _hands_off_to_livekit_cli(component, entry) and not (
                 set(process.run_command) & _LIVEKIT_WORKER_SUBCOMMANDS
             ):

--- a/src/fi/alk/harness/bundle_author_v2.py
+++ b/src/fi/alk/harness/bundle_author_v2.py
@@ -906,6 +906,23 @@ def _dockerfile_run(root: Path) -> list[str] | None:
     return argv
 
 
+# LiveKit's CLI is a subcommand app: `agent.py` with no subcommand prints usage and exits, so the
+# worker never registers. Anything that already starts one is left alone.
+_LIVEKIT_WORKER_SUBCOMMANDS = frozenset({"start", "dev", "connect", "console"})
+
+
+def _hands_off_to_livekit_cli(root: Path, entry: str) -> bool:
+    """Whether the entry script ends in `cli.run_app`, which is what needs the subcommand.
+
+    A repository can also start its worker itself, and appending a subcommand to one of those
+    would break it, so this reads the entry rather than assuming every LiveKit agent is a CLI app.
+    """
+    path = root / entry
+    if not path.is_file():
+        return False
+    return "cli.run_app" in path.read_text(encoding="utf-8", errors="replace")
+
+
 def _discover_callback_entrypoint(root: Path) -> str | None:
     """Return the repository's unique module-level ``agent_callback``, if present.
 
@@ -1285,13 +1302,18 @@ def resolve_environment_plan(
                 }
             )
         if is_livekit:
-            process = process.model_copy(
-                update={
-                    "started_check": StartedCheck(
-                        log_marker="registered worker", timeout_seconds=180
-                    )
-                }
-            )
+            update: dict[str, Any] = {
+                "started_check": StartedCheck(
+                    log_marker="registered worker", timeout_seconds=180
+                )
+            }
+            # A Dockerfile CMD normally carries the subcommand. A repository without one gets a
+            # bare `python agent.py`, which exits on its usage banner before it can register.
+            if _hands_off_to_livekit_cli(component, entry) and not (
+                set(process.run_command) & _LIVEKIT_WORKER_SUBCOMMANDS
+            ):
+                update["run_command"] = [*process.run_command, "start"]
+            process = process.model_copy(update=update)
         processes.append(process)
         if port:
             capabilities["target_http"] = CapabilityV2(

--- a/tests/harness/test_bundle_author_v2.py
+++ b/tests/harness/test_bundle_author_v2.py
@@ -20,16 +20,23 @@ from fi.alk.harness.world.runtime import GeneratedWorld
 
 
 def _job(
-    *, connector: str, with_secrets: bool = False, scenario_count: int = 1
+    *,
+    connector: str,
+    with_secrets: bool = False,
+    scenario_count: int = 1,
+    secret_aliases: tuple[str, ...] = ("LIVEKIT_API_KEY",),
 ) -> HarnessJob:
     secret_refs = {}
     if with_secrets:
+        # A source that really imports livekit declares the full credential set, where a toy
+        # `print('agent')` entry declares none, so a realistic fixture needs more than the key.
         secret_refs = {
-            "LIVEKIT_API_KEY": {
+            alias: {
                 "manager": "platform-vault",
-                "key": "livekit-key",
+                "key": alias.lower().replace("_", "-"),
                 "purpose": "target_provider",
             }
+            for alias in secret_aliases
         }
     return HarnessJob.model_validate(
         {
@@ -168,7 +175,11 @@ def test_auto_voice_contract_compiles_livekit_process_runtime(tmp_path: Path) ->
     )
     authoring = _authoring(tmp_path)
     _write_voice_contract(authoring)
-    job = _job(connector="auto", with_secrets=True)
+    job = _job(
+        connector="auto",
+        with_secrets=True,
+        secret_aliases=("LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "LIVEKIT_URL"),
+    )
 
     bundle = author_bundle_v2(
         source=source, job=job, authoring=authoring, output=tmp_path / "bundle"
@@ -179,6 +190,100 @@ def test_auto_voice_contract_compiles_livekit_process_runtime(tmp_path: Path) ->
     assert agent.environment["HARNESS_MODE"] == "1"
     assert "target_provider" in agent.secret_purposes
     assert "target_http" not in bundle.capabilities
+
+
+def test_livekit_cli_agent_without_a_dockerfile_is_started_with_a_subcommand(
+    tmp_path: Path,
+) -> None:
+    """A repository that ships no Dockerfile has nothing to carry the subcommand.
+
+    LiveKit's CLI prints its usage banner and exits when given none, so the worker never registers
+    and the run fails at `spawn_failed` with the agent already dead.
+    """
+    source = tmp_path / "voice-agent"
+    source.mkdir()
+    (source / "agent.py").write_text(
+        "from livekit.agents import cli, WorkerOptions\n"
+        "if __name__ == '__main__':\n"
+        "    cli.run_app(WorkerOptions(entrypoint_fnc=None))\n",
+        encoding="utf-8",
+    )
+    (source / "requirements.txt").write_text("livekit-agents\n", encoding="utf-8")
+    authoring = _authoring(tmp_path)
+    _write_voice_contract(authoring)
+    job = _job(
+        connector="auto",
+        with_secrets=True,
+        secret_aliases=("LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "LIVEKIT_URL"),
+    )
+
+    bundle = author_bundle_v2(
+        source=source, job=job, authoring=authoring, output=tmp_path / "bundle"
+    )
+
+    agent = next(process for process in bundle.processes if process.name == "agent")
+    assert agent.run_command[-1] == "start"
+
+
+def test_a_dockerfile_command_that_already_starts_a_worker_is_left_alone(
+    tmp_path: Path,
+) -> None:
+    """The subcommand is added where one is missing, never doubled onto a command that has it."""
+    source = tmp_path / "voice-agent"
+    source.mkdir()
+    (source / "agent.py").write_text(
+        "from livekit.agents import cli, WorkerOptions\n"
+        "cli.run_app(WorkerOptions(entrypoint_fnc=None))\n",
+        encoding="utf-8",
+    )
+    (source / "pyproject.toml").write_text(
+        "[project]\nname='agent'\nversion='1'\n", encoding="utf-8"
+    )
+    (source / "Dockerfile").write_text(
+        'FROM python:3.13\nCMD ["python", "agent.py", "start"]\n', encoding="utf-8"
+    )
+    authoring = _authoring(tmp_path)
+    _write_voice_contract(authoring)
+    job = _job(
+        connector="auto",
+        with_secrets=True,
+        secret_aliases=("LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "LIVEKIT_URL"),
+    )
+
+    bundle = author_bundle_v2(
+        source=source, job=job, authoring=authoring, output=tmp_path / "bundle"
+    )
+
+    agent = next(process for process in bundle.processes if process.name == "agent")
+    assert agent.run_command.count("start") == 1
+    assert agent.run_command[-1] == "start"
+
+
+def test_an_agent_that_starts_its_own_worker_gets_no_subcommand(tmp_path: Path) -> None:
+    """Not every LiveKit agent is a CLI app; appending a subcommand to one of those breaks it."""
+    source = tmp_path / "voice-agent"
+    source.mkdir()
+    (source / "agent.py").write_text(
+        "from livekit.agents import Worker, WorkerOptions\n"
+        "import asyncio\n"
+        "asyncio.run(Worker(WorkerOptions(entrypoint_fnc=None)).run())\n",
+        encoding="utf-8",
+    )
+    (source / "requirements.txt").write_text("livekit-agents\n", encoding="utf-8")
+    authoring = _authoring(tmp_path)
+    _write_voice_contract(authoring)
+    job = _job(
+        connector="auto",
+        with_secrets=True,
+        secret_aliases=("LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "LIVEKIT_URL"),
+    )
+
+    bundle = author_bundle_v2(
+        source=source, job=job, authoring=authoring, output=tmp_path / "bundle"
+    )
+
+    agent = next(process for process in bundle.processes if process.name == "agent")
+    assert "start" not in agent.run_command
 
 
 def test_bundle_rejects_missing_runtime_configuration_after_source_checkout(
@@ -216,7 +321,11 @@ def test_bundle_accepts_post_checkout_runtime_configuration_names(
     )
     authoring = _authoring(tmp_path)
     _write_voice_contract(authoring)
-    job = _job(connector="auto", with_secrets=True).model_copy(
+    job = _job(
+        connector="auto",
+        with_secrets=True,
+        secret_aliases=("LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "LIVEKIT_URL"),
+    ).model_copy(
         update={"metadata": {"environment_value_names": ["GOOGLE_CLOUD_PROJECT"]}}
     )
 


### PR DESCRIPTION
## Problem

A LiveKit agent is started by running its entry script, and the run command is built as
`python agent.py` with no CLI subcommand. LiveKit's CLI is a subcommand application, so with none it
prints its usage banner and exits immediately. The worker never registers, and the run fails at
`spawn_failed` with the agent already dead:

```
ProcessRuntimeError: depends_on/spawn_failed (agent):
  agent: exited before started_check passed; last output:
  Usage: agent.py [OPTIONS] COMMAND [ARGS]...
  Commands: console  start  dev  connect  download-files
```

The only thing that supplies a subcommand today is a Dockerfile `CMD`, picked up as a run override.

## Scope

Narrow, and worth stating precisely because it is easy to overstate. This affects a LiveKit voice
agent whose entry hands off to `cli.run_app` and whose repository ships no Dockerfile `CMD`.

Not affected, because none of them reach this branch: agents on other connectors, chat agents, and
agents that construct their own `Worker` rather than delegating to the CLI.

## Change

In the `is_livekit` branch, which already overrides the started check, ensure the run command carries
a worker subcommand, appended only when none is present.

Whether the entry delegates to the CLI is decided by reading it for `cli.run_app`, not assumed.
Appending a subcommand to an agent that runs its own worker would break it.

| repository shape | before | after |
| --- | --- | --- |
| no Dockerfile, entry calls `cli.run_app` | usage banner, worker never registers | `start` appended, worker registers |
| Dockerfile `CMD [..., "start"]` | works | unchanged, subcommand never doubled |
| entry constructs its own `Worker` | works | unchanged, no subcommand added |

## Verification

Unit: three tests, one per row above. Full harness suite 1138 passed, 0 failed.

End to end on a local stack, against a public LiveKit agent repository that ships no Dockerfile.
Before this change it died at `spawn_failed` on the usage banner. After it, the agent log reaches:

```
registered worker      url=wss://...  region=europe-west3
received job request   room=harness-...
```

so the worker registers and accepts the job. Both scenarios still end as a target stall at one turn,
for a reason outside this change: the model provider account configured for that agent returns
`429 insufficient_quota`, so the agent joins the call, transcribes the caller, and can never reply.

Regression: an existing agent that ships a Dockerfile was re-run on the same stack with the same
scenarios as before the change. Two receipts, identical statuses and sub-goal verdicts to the earlier
baseline, at 12 and 61 turns, confirming the Dockerfile path is untouched.

## Follow-up, not in this change

`download-files` is appended only in the `pyproject.toml` build branch of `_plan_python`, so a
`requirements.txt` repository never downloads plugin model files. It did not affect the run above, and
it belongs in its own change.
