### PR TITLE
fix(simulate): stop a finished short call reporting as an infrastructure failure

### DIFF
--- a/src/fi/simulate/simulation/engines/livekit.py
+++ b/src/fi/simulate/simulation/engines/livekit.py
@@ -293,6 +293,9 @@ class _TestRunnerAgent(Agent):
         self._session_turn_handling = turn_handling
         self._session: AgentSession | None = None
         self._end_requested = asyncio.Event()
+        # Recorded for the receipt, not to decide the outcome: it tells a reader whether the
+        # caller tried to hang up and the turn floor turned it away.
+        self._end_refused_by_floor = False
         self._end_speech_handle: Any | None = None
         self._usage_collector = metrics.ModelUsageCollector()
 
@@ -324,6 +327,7 @@ class _TestRunnerAgent(Agent):
                 floor,
                 _has_role_alternation(messages),
             )
+            self._end_refused_by_floor = True
             # "Not yet" rather than "stop asking", or the caller never retries the tool.
             return (
                 f"Not yet: {len(messages)} of {floor} messages so far and both speakers must "
@@ -1777,6 +1781,9 @@ class LiveKitEngine(BaseEngine):
                 stop_reason,
                 messages,
                 min_turn_messages=min_turn_messages,
+                end_refused_by_floor=getattr(
+                    customer_agent, "_end_refused_by_floor", False
+                ),
             )
         except asyncio.TimeoutError:
             stage = (
@@ -3244,6 +3251,7 @@ def _conversation_outcome(
     messages: list[dict[str, str]],
     *,
     min_turn_messages: int,
+    end_refused_by_floor: bool = False,
 ) -> _CaseOutcome:
     transcript = "\n".join(
         f"{message['role']}: {message['content']}" for message in messages
@@ -3266,6 +3274,24 @@ def _conversation_outcome(
             metadata={
                 "stop_reason": stop_reason,
                 "short_terminal_exchange": True,
+            },
+        )
+    if stop_reason == "session_closed" and _agent_answered_the_caller(messages):
+        # A session that closes after the agent has answered is a finished short call, not a
+        # dropped one. Agents whose work takes fewer turns than the floor (a lookup, an FAQ, a
+        # status check) used to be reported as an infrastructure failure for doing their job in
+        # one exchange. A close that leaves the caller's last turn unanswered still fails below,
+        # because that is a call that really was cut off. Whether the work was correct is the
+        # sub-goals' business, not the transport's.
+        return _CaseOutcome(
+            status=TestCaseStatus.COMPLETED,
+            transcript=transcript,
+            messages=messages,
+            metadata={
+                "stop_reason": stop_reason,
+                "short_task_complete": True,
+                "min_turn_messages": str(min_turn_messages),
+                "end_refused_by_floor": str(bool(end_refused_by_floor)).lower(),
             },
         )
     if (
@@ -3382,6 +3408,24 @@ def _conversation_outcome(
         messages=messages,
         metadata={"stop_reason": stop_reason},
     )
+
+
+def _agent_answered_the_caller(messages: list[dict[str, str]]) -> bool:
+    """Whether the agent got the last word after the caller had spoken.
+
+    That is the difference between a call that finished early and one that was cut off. If the
+    caller's last turn went unanswered, the session ended mid-exchange and stays a failure.
+    """
+    spoken = [
+        (str(m.get("role") or "").lower(), str(m.get("content") or "").strip())
+        for m in messages
+    ]
+    spoken = [(role, text) for role, text in spoken if text]
+    if not spoken:
+        return False
+    if not any(role == "user" for role, _ in spoken):
+        return False
+    return spoken[-1][0] == "assistant"
 
 
 def _has_natural_terminal_exchange(messages: list[dict[str, str]]) -> bool:

--- a/tests/runtime/test_livekit_engine.py
+++ b/tests/runtime/test_livekit_engine.py
@@ -1858,6 +1858,52 @@ def test_safe_provider_error_details_include_sip_status_metadata() -> None:
     }
 
 
+def test_short_task_that_asked_to_end_is_completed_not_failed() -> None:
+    """An agent whose work takes fewer turns than the floor must not read as a call failure.
+
+    The caller finished its task, reached for endCall, and the minimum-turn floor turned it away.
+    With nothing left to say its session closed, which used to surface as an infrastructure
+    `call_failed` even though the agent had answered correctly.
+    """
+    messages = [
+        {"role": "assistant", "content": "Hello, I'm Katie. How can I help you today?"},
+        {"role": "user", "content": "What is the weather in Austin right now?"},
+        {
+            "role": "assistant",
+            "content": "It's sunny and 70 degrees in Austin. Anything else I can help with?",
+        },
+    ]
+
+    outcome = livekit._conversation_outcome(
+        "session_closed",
+        messages,
+        min_turn_messages=6,
+        end_refused_by_floor=True,
+    )
+
+    assert outcome.status == CaseStatus.COMPLETED
+    assert outcome.failure is None
+    assert outcome.metadata["short_task_complete"] is True
+
+
+def test_session_closed_on_an_unanswered_question_still_fails() -> None:
+    """A close that leaves the caller's last turn unanswered was cut off, not finished."""
+    messages = [
+        {"role": "assistant", "content": "Hello, I'm Katie. How can I help you today?"},
+        {"role": "user", "content": "What is the weather in Austin right now?"},
+    ]
+
+    outcome = livekit._conversation_outcome(
+        "session_closed",
+        messages,
+        min_turn_messages=6,
+    )
+
+    assert outcome.status == CaseStatus.FAILED
+    assert outcome.failure is not None
+    assert outcome.failure.code == "session_closed"
+
+
 @pytest.mark.parametrize(
     ("stop_reason", "messages", "failure_code"),
     [


### PR DESCRIPTION
## Problem

A call where the agent did its job is reported as an infrastructure failure when the conversation is
shorter than the minimum-turn floor.

`call_runner.py` sets the floor per connector:

```python
min_turn_messages = 5 if connector in {"vapi", "retell"} else 6
```

That count is both sides combined. An agent whose task genuinely completes in one exchange finishes
well inside it:

```
[assistant] Hello, I'm Katie. How can I help you today?
[user]      What is the weather in Austin right now?
[assistant] It's sunny and 70 degrees in Austin. Anything else I can help with?
```

Three messages, task done, tool call succeeded. The caller has nothing left to say, its session
closes, and the run is reported as:

```
Infrastructure · Call failed
voice_call_not_completed: Conversation session closed before a natural end condition
```

Nothing infrastructural failed. This affects any short-task agent: a lookup, an FAQ line, a status
check.

There is already a waiver for this shape, but it only fires when the target has gone quiet. An agent
that closes politely with "anything else I can help you with?" has not gone quiet, so an agent with
good manners is the one penalised.

## Change

`session_closed` is treated as a completed call when the agent had the last word after the caller had
spoken, which is what separates a call that finished early from one that was cut off.

A close that leaves the caller's last turn unanswered still fails, because that call really was
interrupted. Whether the agent's work was correct stays with the sub-goals, where it belongs; this
only stops the transport claiming a failure it did not have.

The receipt records `short_task_complete`, the floor in force, and whether the caller had reached for
`endCall` and been refused, so a reader can see why the call ended without digging into logs.

This follows the two existing precedents in the same function, `short_terminal_exchange` and
`terminal_exchange_recovered`, which already map a benign stop reason to `COMPLETED` with metadata.

## Why not simply lower the floor

Any fixed number is wrong for some agent: three turns is complete for a weather lookup and truncated
for a claims intake. The floor still does its real job, which is stopping a simulator hanging up
before a conversation has happened. What changes is only that the resulting close is no longer
mislabelled.

## Tests

Two added:
- a three-message exchange ending with the agent's answer is `COMPLETED`, with `short_task_complete`
  on the receipt
- a close that leaves the caller's question unanswered is still `FAILED` with `session_closed`

`tests/runtime/` and `tests/harness/`: 1267 passed. The single failure,
`test_simulator_collects_normalized_model_usage`, is present on the base branch without this change
and is unrelated.
