### PR TITLE
ci: least-privilege GITHUB_TOKEN permissions on new workflows

### DIFF
--- a/.github/workflows/daytona-snapshot.yml
+++ b/.github/workflows/daytona-snapshot.yml
@@ -5,6 +5,10 @@ name: Daytona snapshot
 # base runtime or the ALK guest changes). PRs/pushes that touch the runtime run
 # a dry-run that parses the Dockerfile + build context without publishing.
 
+# Least-privilege token: both jobs only checkout and run scripts.
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -1,5 +1,9 @@
 name: SDK smoke
 
+# Least-privilege token: install + test only.
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
## What
Adds a top-level `permissions:` block to the two GitHub Actions workflows introduced in #91:

- `.github/workflows/daytona-snapshot.yml`
- `.github/workflows/sdk-smoke.yml`

Both get `permissions: contents: read`.

## Why
CodeQL raised three `actions/missing-workflow-permissions` alerts (medium) on these new workflows because neither declared a `permissions` block, so `GITHUB_TOKEN` defaulted to a broad scope. Every job in both files only runs `actions/checkout` + `actions/setup-python` and scripts/tests — no GitHub API writes, no artifact upload, no OIDC — so `contents: read` is the minimal sufficient scope. Repo secrets (e.g. `DAYTONA_API_KEY`) are unaffected by the permissions block.

Resolves all three alerts introduced by #91.

## Note
The five high-severity CodeQL alerts on the TS files (`js/clear-text-logging`, `js/polynomial-redos`) are pre-existing (not touched by #91) and are out of scope for this fix; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)