### PR TITLE
ci: publish agent-learning-kit to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,28 +1,9 @@
-# Publishes agent-learning-kit to PyPI via Trusted Publishing (OIDC): no
-# long-lived PyPI token anywhere.
-#
-# PyPI-side one-time setup — the project does NOT exist on PyPI yet, so this
-# must be a PENDING publisher created at ACCOUNT level (not under a project):
-#   https://pypi.org/manage/account/publishing/  → "Add a new pending publisher"
-#   project=agent-learning-kit  owner=future-agi  repo=agent-learning-kit
-#   workflow=publish-pypi.yml   environment=pypi
-# Do this from the ORG PyPI account: whichever account creates the pending
-# publisher becomes the project owner. A pending publisher does NOT reserve
-# the name — register it and land the first release promptly.
-#
-# Trigger: every push to main (i.e. every merged PR). A release happens ONLY
-# when the pyproject version is not yet on PyPI — the `check` job looks it up
-# and skips everything otherwise, so ordinary merges stay green and never
-# wake the reviewer. To release: bump `version` in pyproject.toml (+ uv lock),
-# merge to main, approve the `pypi` environment deployment when it pauses.
-# Each version publishes exactly once (PyPI is immutable); a mistake needs a
-# new version, never a re-upload.
-#
-# Gates: main is protected by the branch ruleset (PR approval to merge), and
-# the `pypi` environment requires a reviewer (prevent self-review) before the
-# publish job gets its OIDC token. PyPI's trust check binds only
-# (repo, workflow file, environment), not the ref — those two gates ARE the
-# authorization. There is deliberately no workflow_dispatch and no tag trigger.
+# Publishes agent-learning-kit to PyPI (Trusted Publishing) on merge to main,
+# only when the pyproject version is not yet on PyPI.
+# Release: bump `version` in pyproject.toml + `uv lock`, merge, approve the
+# `pypi` environment deployment. PyPI publisher: pending publisher at
+# https://pypi.org/manage/account/publishing/ (repo agent-learning-kit,
+# workflow publish-pypi.yml, environment pypi).
 name: publish-pypi
 
 on:
@@ -34,7 +15,11 @@ permissions:
 
 concurrency:
   group: publish-pypi-main
-  cancel-in-progress: false      # never cancel a publish mid-flight; queue instead
+  cancel-in-progress: false
+
+env:
+  PYPI_PROJECT: agent-learning-kit
+  UV_VERSION: "0.12.9"
 
 jobs:
   check:
@@ -49,24 +34,36 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
-          version: ">=0.12,<0.13"
-      - name: Decide — is the pyproject version already on PyPI?
-        id: v
+          version: ${{ env.UV_VERSION }}
+      - id: v
         env:
           REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+          HEADLINE: ${{ github.event.head_commit.message }}
         shell: bash
         run: |
           set -euo pipefail
           [[ "$REF" == refs/heads/main ]] || { echo "::error::refusing to publish from $REF"; exit 1; }
           version="$(uv version --short)"
-          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z0-9.]*)$ ]] || { echo "::error::pyproject version '$version' is not a release version"; exit 1; }
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z0-9.]*)$ ]] || { echo "::error::unexpected version shape"; exit 1; }
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          code="$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/agent-learning-kit/${version}/json")"
+          wheel="agent_learning_kit-${version}-py3-none-any.whl"; sdist="agent_learning_kit-${version}.tar.gz"
+          body="$(mktemp)"
+          code="$(curl -sS --max-time 30 --retry 3 --retry-delay 2 -o "$body" -w '%{http_code}' \
+                  "https://pypi.org/pypi/${PYPI_PROJECT}/json")"
           case "$code" in
-            404) echo "publish=true"  >> "$GITHUB_OUTPUT"; echo "agent-learning-kit ${version} not on PyPI — will publish" ;;
-            200) echo "publish=false" >> "$GITHUB_OUTPUT"; echo "agent-learning-kit ${version} already on PyPI — nothing to do" ;;
-            *)   echo "::error::PyPI lookup returned HTTP $code — refusing to guess"; exit 1 ;;
+            404) publish=true;  why="first release" ;;
+            200) if jq -e --arg v "$version" --arg w "$wheel" --arg s "$sdist" \
+                       '(.releases[$v] // []) | map(.filename) | (index($w) != null and index($s) != null)' "$body" >/dev/null
+                 then publish=false; why="already on PyPI"
+                 else publish=true;  why="not on PyPI"; fi ;;
+            *)   echo "::error::PyPI lookup returned HTTP $code"; exit 1 ;;
           esac
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          {
+            echo "## ${PYPI_PROJECT} **${version}** — ${why}"
+            echo "- commit: \`${SHA}\` — ${HEADLINE%%$'\n'*}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build:
     needs: check
@@ -76,17 +73,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false   # no GITHUB_TOKEN left in .git for the smoke step's import-time code
+          persist-credentials: false
       - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
-          version: ">=0.12,<0.13"      # what the release was verified with (0.12.x); don't let the build tool float
+          version: ${{ env.UV_VERSION }}
       - run: uv build
-      - name: Smoke — the wheel must import the hosted-runner entrypoints and expose the CLI
-        run: |
+      - run: |
           set -euo pipefail
-          uv venv .smoke --python 3.12          # pinned: matches sdk-smoke.yml
+          uv venv .smoke --python 3.12
           uv pip install --python .smoke/bin/python dist/*.whl
-          .smoke/bin/python -c "import fi.simulate.hosted.child_entrypoint, fi.alk.harness; print('ok')"
+          .smoke/bin/python -c "import fi.simulate.hosted.child_entrypoint, fi.alk.harness"
           .smoke/bin/alk --help > /dev/null
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -99,18 +95,42 @@ jobs:
     if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: pypi            # required reviewer (prevent self-review) + OIDC trust live here
+    environment: pypi
     permissions:
-      id-token: write            # OIDC for Trusted Publishing — this job only downloads + publishes
+      id-token: write
       contents: read
+    env:
+      VERSION: ${{ needs.check.outputs.version }}
     steps:
+      - id: recheck
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheel="agent_learning_kit-${VERSION}-py3-none-any.whl"; sdist="agent_learning_kit-${VERSION}.tar.gz"
+          body="$(mktemp)"
+          code="$(curl -sS --max-time 30 --retry 3 --retry-delay 2 -o "$body" -w '%{http_code}' \
+                  "https://pypi.org/pypi/${PYPI_PROJECT}/json")"
+          if [[ "$code" == 200 ]] && jq -e --arg v "$VERSION" --arg w "$wheel" --arg s "$sdist" \
+               '(.releases[$v] // []) | map(.filename) | (index($w) != null and index($s) != null)' "$body" >/dev/null; then
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$code" == 200 || "$code" == 404 ]]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::PyPI lookup returned HTTP $code"; exit 1
+          fi
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: steps.recheck.outputs.go == 'true'
         with:
           name: dist
           path: dist/
-      # SHA-pinned: release/v1 is a moving branch on this action.
-      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 as of 2026-09-12
+      - if: steps.recheck.outputs.go == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected=$(printf '%s\n' "agent_learning_kit-${VERSION}-py3-none-any.whl" "agent_learning_kit-${VERSION}.tar.gz" | sort)
+          [[ "$(ls -1 dist/ | sort)" == "$expected" ]] || { echo "::error::dist/ does not match version ${VERSION}"; ls -la dist/; exit 1; }
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        if: steps.recheck.outputs.go == 'true'
         with:
-          attestations: true     # PEP 740 provenance for sdist + wheel (explicit, not default-reliant)
-          skip-existing: true    # a re-run after a partial upload (wheel ok, sdist failed) must not 400 on "File already exists"
-      - run: echo "Published agent-learning-kit ${{ needs.check.outputs.version }} to PyPI" >> "$GITHUB_STEP_SUMMARY"
+          attestations: true
+          skip-existing: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,56 @@
+# DRAFT — future-agi/agent-learning-kit/.github/workflows/publish-pypi.yml
+# Publishes agent-learning-kit to PyPI via Trusted Publishing (OIDC): no
+# long-lived PyPI token anywhere. PyPI-side one-time setup (project owner):
+#   PyPI → project "agent-learning-kit" → Publishing → add GitHub publisher
+#   owner=future-agi  repo=agent-learning-kit  workflow=publish-pypi.yml  environment=pypi
+# Triggered by pushing a release tag (sdk-vX.Y.Z) whose pyproject version must
+# match — the guard below refuses a mismatch so a tag can never publish the
+# wrong version. workflow_dispatch is a manual re-run only.
+name: publish-pypi
+
+on:
+  push:
+    tags: ['sdk-v[0-9]+.[0-9]+.[0-9]+']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Guard — tag must equal pyproject version
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          want="${TAG#sdk-v}"
+          have="$(uv version --short)"
+          [[ "$want" == "$have" ]] || { echo "::error::tag $TAG != pyproject version $have"; exit 1; }
+      - run: uv build
+      - name: Smoke — the wheel must import the hosted entrypoint
+        run: |
+          set -euo pipefail
+          uv venv .smoke && . .smoke/bin/activate
+          uv pip install dist/*.whl
+          python -c "import fi.simulate.hosted.child_entrypoint, fi.alk.harness; print('ok')"
+      - uses: actions/upload-artifact@v4
+        with: { name: dist, path: dist/, if-no-files-found: error }
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi          # bind the OIDC trust + optional required reviewer here
+    permissions:
+      id-token: write          # OIDC for Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: dist, path: dist/ }
+      # SHA-pinned: release/v1 is a moving branch on this action.
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 as of 2026-09-12

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -8,32 +8,69 @@
 #   workflow=publish-pypi.yml   environment=pypi
 # Do this from the ORG PyPI account: whichever account creates the pending
 # publisher becomes the project owner. A pending publisher does NOT reserve
-# the name — register it and push the first sdk-v* tag in the same sitting.
+# the name — register it and land the first release promptly.
 #
-# Trigger: ONLY a pushed release tag sdk-vX.Y.Z whose version equals the
-# pyproject version. There is deliberately no workflow_dispatch — it would
-# let any push-capable account publish an arbitrary ref while skipping the
-# tag guard; a failed publish is re-run from the original tag run in the
-# Actions UI (skip-existing makes that idempotent). PyPI's trust check binds
-# only (repo, workflow file, environment), not the ref — so the real gate is
-# repo-side: a tag ruleset on sdk-v* and a required reviewer + an sdk-v*
-# deployment-tag policy on the `pypi` environment (without the tag policy the
-# environment refuses tag-triggered deploys, or gates nothing).
+# Trigger: every push to main (i.e. every merged PR). A release happens ONLY
+# when the pyproject version is not yet on PyPI — the `check` job looks it up
+# and skips everything otherwise, so ordinary merges stay green and never
+# wake the reviewer. To release: bump `version` in pyproject.toml (+ uv lock),
+# merge to main, approve the `pypi` environment deployment when it pauses.
+# Each version publishes exactly once (PyPI is immutable); a mistake needs a
+# new version, never a re-upload.
+#
+# Gates: main is protected by the branch ruleset (PR approval to merge), and
+# the `pypi` environment requires a reviewer (prevent self-review) before the
+# publish job gets its OIDC token. PyPI's trust check binds only
+# (repo, workflow file, environment), not the ref — those two gates ARE the
+# authorization. There is deliberately no workflow_dispatch and no tag trigger.
 name: publish-pypi
 
 on:
   push:
-    tags: ['sdk-v[0-9]+.[0-9]+.[0-9]+']
+    branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-pypi-${{ github.ref_name }}
-  cancel-in-progress: false
+  group: publish-pypi-main
+  cancel-in-progress: false      # never cancel a publish mid-flight; queue instead
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.v.outputs.publish }}
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+        with:
+          version: ">=0.12,<0.13"
+      - name: Decide — is the pyproject version already on PyPI?
+        id: v
+        env:
+          REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$REF" == refs/heads/main ]] || { echo "::error::refusing to publish from $REF"; exit 1; }
+          version="$(uv version --short)"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z0-9.]*)$ ]] || { echo "::error::pyproject version '$version' is not a release version"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/agent-learning-kit/${version}/json")"
+          case "$code" in
+            404) echo "publish=true"  >> "$GITHUB_OUTPUT"; echo "agent-learning-kit ${version} not on PyPI — will publish" ;;
+            200) echo "publish=false" >> "$GITHUB_OUTPUT"; echo "agent-learning-kit ${version} already on PyPI — nothing to do" ;;
+            *)   echo "::error::PyPI lookup returned HTTP $code — refusing to guess"; exit 1 ;;
+          esac
+
   build:
+    needs: check
+    if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -43,16 +80,6 @@ jobs:
       - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           version: ">=0.12,<0.13"      # what the release was verified with (0.12.x); don't let the build tool float
-      - name: Guard — must be a release tag equal to the pyproject version
-        env:
-          REF: ${{ github.ref }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$REF" == refs/tags/sdk-v* ]] || { echo "::error::refusing to publish from $REF (not an sdk-v* release tag)"; exit 1; }
-          want="${REF#refs/tags/sdk-v}"
-          have="$(uv version --short)"
-          [[ "$want" == "$have" ]] || { echo "::error::tag version $want != pyproject version $have"; exit 1; }
       - run: uv build
       - name: Smoke — the wheel must import the hosted-runner entrypoints and expose the CLI
         run: |
@@ -68,10 +95,11 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: build
+    needs: [check, build]
+    if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: pypi            # OIDC trust + required reviewer + sdk-v* deployment-tag policy live here
+    environment: pypi            # required reviewer (prevent self-review) + OIDC trust live here
     permissions:
       id-token: write            # OIDC for Trusted Publishing — this job only downloads + publishes
       contents: read
@@ -85,3 +113,4 @@ jobs:
         with:
           attestations: true     # PEP 740 provenance for sdist + wheel (explicit, not default-reliant)
           skip-existing: true    # a re-run after a partial upload (wheel ok, sdist failed) must not 400 on "File already exists"
+      - run: echo "Published agent-learning-kit ${{ needs.check.outputs.version }} to PyPI" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,56 +1,74 @@
-# DRAFT — future-agi/agent-learning-kit/.github/workflows/publish-pypi.yml
 # Publishes agent-learning-kit to PyPI via Trusted Publishing (OIDC): no
 # long-lived PyPI token anywhere. PyPI-side one-time setup (project owner):
-#   PyPI → project "agent-learning-kit" → Publishing → add GitHub publisher
+#   PyPI → Publishing → add pending GitHub publisher:
 #   owner=future-agi  repo=agent-learning-kit  workflow=publish-pypi.yml  environment=pypi
-# Triggered by pushing a release tag (sdk-vX.Y.Z) whose pyproject version must
-# match — the guard below refuses a mismatch so a tag can never publish the
-# wrong version. workflow_dispatch is a manual re-run only.
+#
+# Trigger: ONLY a pushed release tag sdk-vX.Y.Z whose version equals the
+# pyproject version. There is deliberately no workflow_dispatch — it would
+# let any push-capable account publish an arbitrary ref while skipping the
+# tag guard; a failed publish is re-run from the original tag run in the
+# Actions UI. PyPI's trust check binds only (repo, workflow file, environment),
+# not the ref — so the real gate is repo-side: a tag ruleset on sdk-v* and a
+# required reviewer + sdk-v* deployment policy on the `pypi` environment.
 name: publish-pypi
 
 on:
   push:
     tags: ['sdk-v[0-9]+.[0-9]+.[0-9]+']
-  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: publish-pypi-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-      - name: Guard — tag must equal pyproject version
-        if: github.event_name == 'push'
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false   # no GITHUB_TOKEN left in .git for the smoke step's import-time code
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+      - name: Guard — must be a release tag equal to the pyproject version
         env:
-          TAG: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
         shell: bash
         run: |
           set -euo pipefail
-          want="${TAG#sdk-v}"
+          [[ "$REF" == refs/tags/sdk-v* ]] || { echo "::error::refusing to publish from $REF (not an sdk-v* release tag)"; exit 1; }
+          want="${REF#refs/tags/sdk-v}"
           have="$(uv version --short)"
-          [[ "$want" == "$have" ]] || { echo "::error::tag $TAG != pyproject version $have"; exit 1; }
+          [[ "$want" == "$have" ]] || { echo "::error::tag version $want != pyproject version $have"; exit 1; }
       - run: uv build
-      - name: Smoke — the wheel must import the hosted entrypoint
+      - name: Smoke — the wheel must import the hosted-runner entrypoints
         run: |
           set -euo pipefail
-          uv venv .smoke && . .smoke/bin/activate
-          uv pip install dist/*.whl
-          python -c "import fi.simulate.hosted.child_entrypoint, fi.alk.harness; print('ok')"
-      - uses: actions/upload-artifact@v4
-        with: { name: dist, path: dist/, if-no-files-found: error }
+          uv venv .smoke
+          uv pip install --python .smoke/bin/python dist/*.whl
+          .smoke/bin/python -c "import fi.simulate.hosted.child_entrypoint, fi.alk.harness; print('ok')"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
 
   publish:
     needs: build
     runs-on: ubuntu-latest
-    environment: pypi          # bind the OIDC trust + optional required reviewer here
+    timeout-minutes: 10
+    environment: pypi            # OIDC trust + required reviewer + sdk-v* deployment policy live here
     permissions:
-      id-token: write          # OIDC for Trusted Publishing
+      id-token: write            # OIDC for Trusted Publishing — this job only downloads + publishes
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
-        with: { name: dist, path: dist/ }
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
       # SHA-pinned: release/v1 is a moving branch on this action.
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 as of 2026-09-12
+        with:
+          attestations: true     # PEP 740 provenance for sdist + wheel (explicit, not default-reliant)

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,15 +1,24 @@
 # Publishes agent-learning-kit to PyPI via Trusted Publishing (OIDC): no
-# long-lived PyPI token anywhere. PyPI-side one-time setup (project owner):
-#   PyPI → Publishing → add pending GitHub publisher:
-#   owner=future-agi  repo=agent-learning-kit  workflow=publish-pypi.yml  environment=pypi
+# long-lived PyPI token anywhere.
+#
+# PyPI-side one-time setup — the project does NOT exist on PyPI yet, so this
+# must be a PENDING publisher created at ACCOUNT level (not under a project):
+#   https://pypi.org/manage/account/publishing/  → "Add a new pending publisher"
+#   project=agent-learning-kit  owner=future-agi  repo=agent-learning-kit
+#   workflow=publish-pypi.yml   environment=pypi
+# Do this from the ORG PyPI account: whichever account creates the pending
+# publisher becomes the project owner. A pending publisher does NOT reserve
+# the name — register it and push the first sdk-v* tag in the same sitting.
 #
 # Trigger: ONLY a pushed release tag sdk-vX.Y.Z whose version equals the
 # pyproject version. There is deliberately no workflow_dispatch — it would
 # let any push-capable account publish an arbitrary ref while skipping the
 # tag guard; a failed publish is re-run from the original tag run in the
-# Actions UI. PyPI's trust check binds only (repo, workflow file, environment),
-# not the ref — so the real gate is repo-side: a tag ruleset on sdk-v* and a
-# required reviewer + sdk-v* deployment policy on the `pypi` environment.
+# Actions UI (skip-existing makes that idempotent). PyPI's trust check binds
+# only (repo, workflow file, environment), not the ref — so the real gate is
+# repo-side: a tag ruleset on sdk-v* and a required reviewer + an sdk-v*
+# deployment-tag policy on the `pypi` environment (without the tag policy the
+# environment refuses tag-triggered deploys, or gates nothing).
 name: publish-pypi
 
 on:
@@ -32,6 +41,8 @@ jobs:
         with:
           persist-credentials: false   # no GITHUB_TOKEN left in .git for the smoke step's import-time code
       - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+        with:
+          version: ">=0.12,<0.13"      # what the release was verified with (0.12.x); don't let the build tool float
       - name: Guard — must be a release tag equal to the pyproject version
         env:
           REF: ${{ github.ref }}
@@ -43,12 +54,13 @@ jobs:
           have="$(uv version --short)"
           [[ "$want" == "$have" ]] || { echo "::error::tag version $want != pyproject version $have"; exit 1; }
       - run: uv build
-      - name: Smoke — the wheel must import the hosted-runner entrypoints
+      - name: Smoke — the wheel must import the hosted-runner entrypoints and expose the CLI
         run: |
           set -euo pipefail
-          uv venv .smoke
+          uv venv .smoke --python 3.12          # pinned: matches sdk-smoke.yml
           uv pip install --python .smoke/bin/python dist/*.whl
           .smoke/bin/python -c "import fi.simulate.hosted.child_entrypoint, fi.alk.harness; print('ok')"
+          .smoke/bin/alk --help > /dev/null
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
@@ -59,7 +71,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: pypi            # OIDC trust + required reviewer + sdk-v* deployment policy live here
+    environment: pypi            # OIDC trust + required reviewer + sdk-v* deployment-tag policy live here
     permissions:
       id-token: write            # OIDC for Trusted Publishing — this job only downloads + publishes
       contents: read
@@ -72,3 +84,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 as of 2026-09-12
         with:
           attestations: true     # PEP 740 provenance for sdist + wheel (explicit, not default-reliant)
+          skip-existing: true    # a re-run after a partial upload (wheel ok, sdist failed) must not 400 on "File already exists"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/futureagi-mark-email.png" alt="Future AGI" width="72" />
+  <img src="https://raw.githubusercontent.com/future-agi/agent-learning-kit/main/docs/assets/futureagi-mark-email.png" alt="Future AGI" width="72" />
 </p>
 
 <h1 align="center">Agent Learning Kit</h1>
@@ -9,20 +9,20 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE">Apache-2.0</a>
+  <a href="https://github.com/future-agi/agent-learning-kit/blob/main/LICENSE">Apache-2.0</a>
   ·
-  <a href="docs/index.md">Docs</a>
+  <a href="https://github.com/future-agi/agent-learning-kit/blob/main/docs/index.md">Docs</a>
   ·
-  <a href="CONTRIBUTING.md">Contributing</a>
+  <a href="https://github.com/future-agi/agent-learning-kit/blob/main/CONTRIBUTING.md">Contributing</a>
   ·
-  <a href="SECURITY.md">Security</a>
+  <a href="https://github.com/future-agi/agent-learning-kit/blob/main/SECURITY.md">Security</a>
   ·
-  <a href="ROADMAP.md">V1 roadmap</a>
+  <a href="https://github.com/future-agi/agent-learning-kit/blob/main/ROADMAP.md">V1 roadmap</a>
   ·
-  <a href="LIBRARIES.md">Library inventory</a>
+  <a href="https://github.com/future-agi/agent-learning-kit/blob/main/LIBRARIES.md">Library inventory</a>
 </p>
 
-![Agent Learning lifecycle blueprint](docs/assets/hero-agent-blueprint.jpg)
+![Agent Learning lifecycle blueprint](https://raw.githubusercontent.com/future-agi/agent-learning-kit/main/docs/assets/hero-agent-blueprint.jpg)
 
 Agent Learning Kit is the local-first SDK and CLI for testing, simulating,
 red-teaming, and optimizing AI agents.
@@ -53,10 +53,10 @@ Point it at an agent's source and it reads what that agent verifiably is, builds
 tools act on, and writes test scenarios that are each proved before they are kept. It is driven
 as a conversation, in a terminal or on a web page.
 
-- **[Start here](src/fi/alk/harness/README.md)**: setup from nothing, then how to use it
-- **[The web page](harness-ui/README.md)**: the same harness as a chat, on `localhost:8777`
-- **[How it works](src/fi/alk/harness/HOW-IT-WORKS.md)** and
-  **[why it is shaped this way](src/fi/alk/harness/DESIGN.md)**
+- **[Start here](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/alk/harness/README.md)**: setup from nothing, then how to use it
+- **[The web page](https://github.com/future-agi/agent-learning-kit/blob/main/harness-ui/README.md)**: the same harness as a chat, on `localhost:8777`
+- **[How it works](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/alk/harness/HOW-IT-WORKS.md)** and
+  **[why it is shaped this way](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/alk/harness/DESIGN.md)**
 
 OpenEnv/Gymnasium shapes are compatibility inputs, not the product center.
 Agent Learning Kit is the primary runtime and release contract, and the bar is
@@ -90,7 +90,7 @@ pip install "agent-learning-kit[all]"
 ```
 
 TypeScript evaluation package (npm at launch; today build from
-[`typescript/agent-learning-kit`](typescript/agent-learning-kit)):
+[`typescript/agent-learning-kit`](https://github.com/future-agi/agent-learning-kit/blob/main/typescript/agent-learning-kit)):
 
 ```bash
 pnpm add @future-agi/agent-learning-kit
@@ -111,7 +111,7 @@ Then run the golden path against the bundled example manifests. The
 credential, so any placeholder value works.
 
 > Prefer the SDK spine over the CLI?
-> [Spec + Runner](docs/simulate/spec-and-runner.md) runs the same simulation as
+> [Spec + Runner](https://github.com/future-agi/agent-learning-kit/blob/main/docs/simulate/spec-and-runner.md) runs the same simulation as
 > one `SimulationSpec` fed to one `SimulationRunner` — the plug-and-play surface
 > behind every simulation.
 
@@ -154,7 +154,7 @@ Optional platform mode: to use Future AGI platform-backed evaluation, set
 `AGENT_LEARNING_API_KEY` (it takes precedence over the `FUTURE_AGI_API_KEY`
 and `FI_API_KEY` aliases), or call `configure(api_key="...")` from
 `fi.alk`. See
-[docs/reference/configure.md](docs/reference/configure.md).
+[docs/reference/configure.md](https://github.com/future-agi/agent-learning-kit/blob/main/docs/reference/configure.md).
 
 Cut local release proof:
 
@@ -203,30 +203,30 @@ The public SDK is `agent-learning-kit`, the Python namespace is
 The active `ai-evaluation` code is included here under `src/fi/evals`, with its
 TypeScript SDK source under `typescript/agent-learning-kit/src`. The
 `simulate-sdk` and `agent-opt` engine code is included under `src/fi/simulate`
-and `src/fi/opt`. See [LIBRARIES.md](LIBRARIES.md) for the complete source map.
+and `src/fi/opt`. See [LIBRARIES.md](https://github.com/future-agi/agent-learning-kit/blob/main/LIBRARIES.md) for the complete source map.
 The ai-evaluation source inventory used by `agent-learn release-check` lives at
 the ai-evaluation source inventory (maintained in the internal-docs repo).
 
 ## Repository Map
 
-- [`examples/`](examples): runnable cookbooks and manifests.
-- [`src/fi/alk`](src/fi/alk): public Python SDK facade and CLI.
-- [`src/fi/evals`](src/fi/evals): active `ai-evaluation` engine code.
-- [`src/fi/simulate`](src/fi/simulate): migrated `simulate-sdk` engine code.
-- [`src/fi/opt`](src/fi/opt): migrated `agent-opt` engine code.
-- [`typescript/agent-learning-kit`](typescript/agent-learning-kit): public
+- [`examples/`](https://github.com/future-agi/agent-learning-kit/blob/main/examples): runnable cookbooks and manifests.
+- [`src/fi/alk`](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/alk): public Python SDK facade and CLI.
+- [`src/fi/evals`](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/evals): active `ai-evaluation` engine code.
+- [`src/fi/simulate`](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/simulate): migrated `simulate-sdk` engine code.
+- [`src/fi/opt`](https://github.com/future-agi/agent-learning-kit/blob/main/src/fi/opt): migrated `agent-opt` engine code.
+- [`typescript/agent-learning-kit`](https://github.com/future-agi/agent-learning-kit/blob/main/typescript/agent-learning-kit): public
   TypeScript package, including the active evaluation SDK source.
-- [`docs/index.md`](docs/index.md): full documentation index.
-- [`ROADMAP.md`](ROADMAP.md): public v1 roadmap and post-v1 extensions.
-- [`LIBRARIES.md`](LIBRARIES.md): source map for the consolidated engines.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md): local development and PR workflow.
-- [`SECURITY.md`](SECURITY.md): vulnerability reporting policy.
-- [`LICENSE`](LICENSE): Apache-2.0 license.
-- [`NOTICE`](NOTICE): Apache notice metadata.
+- [`docs/index.md`](https://github.com/future-agi/agent-learning-kit/blob/main/docs/index.md): full documentation index.
+- [`ROADMAP.md`](https://github.com/future-agi/agent-learning-kit/blob/main/ROADMAP.md): public v1 roadmap and post-v1 extensions.
+- [`LIBRARIES.md`](https://github.com/future-agi/agent-learning-kit/blob/main/LIBRARIES.md): source map for the consolidated engines.
+- [`CONTRIBUTING.md`](https://github.com/future-agi/agent-learning-kit/blob/main/CONTRIBUTING.md): local development and PR workflow.
+- [`SECURITY.md`](https://github.com/future-agi/agent-learning-kit/blob/main/SECURITY.md): vulnerability reporting policy.
+- [`LICENSE`](https://github.com/future-agi/agent-learning-kit/blob/main/LICENSE): Apache-2.0 license.
+- [`NOTICE`](https://github.com/future-agi/agent-learning-kit/blob/main/NOTICE): Apache notice metadata.
 
 ## Development
 
-New public SDK development belongs here. See [DEVELOPMENT.md](DEVELOPMENT.md)
+New public SDK development belongs here. See [DEVELOPMENT.md](https://github.com/future-agi/agent-learning-kit/blob/main/DEVELOPMENT.md)
 for the boundary between this package and the backing engine repos.
 
 ```bash
@@ -271,12 +271,12 @@ extensions land post-v1 without weakening any gate.
 
 ## Community
 
-- Contributions: [CONTRIBUTING.md](CONTRIBUTING.md)
-- Code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- Security reports: [SECURITY.md](SECURITY.md)
-- License: [Apache-2.0](LICENSE)
+- Contributions: [CONTRIBUTING.md](https://github.com/future-agi/agent-learning-kit/blob/main/CONTRIBUTING.md)
+- Code of conduct: [CODE_OF_CONDUCT.md](https://github.com/future-agi/agent-learning-kit/blob/main/CODE_OF_CONDUCT.md)
+- Security reports: [SECURITY.md](https://github.com/future-agi/agent-learning-kit/blob/main/SECURITY.md)
+- License: [Apache-2.0](https://github.com/future-agi/agent-learning-kit/blob/main/LICENSE)
 
 ## Deep Dive
 
 The full documentation set — quickstarts, per-track guides, framework pages,
-and reference material — starts at [docs/index.md](docs/index.md).
+and reference material — starts at [docs/index.md](https://github.com/future-agi/agent-learning-kit/blob/main/docs/index.md).

--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ OpenEnv/Gymnasium-shaped traces remain compatibility evidence inside that bar.
 
 ## Install
 
-PyPI and npm publishing land at the v1 launch. Today, install from source:
-
-```bash
-git clone https://github.com/future-agi/agent-learning-kit
-cd agent-learning-kit
-pip install -e .
-```
-
-(or `uv sync` for contributors)
-
-At launch:
+Install from PyPI:
 
 ```bash
 pip install agent-learning-kit
 ```
+
+To develop against source (contributors):
+
+```bash
+git clone https://github.com/future-agi/agent-learning-kit
+cd agent-learning-kit
+uv sync          # or: pip install -e .
+```
+
+(npm publishing of the TypeScript SDK lands at the v1 launch.)
 
 Optional Python extras:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["hatchling"]
+# Bounded: the build backend is the one artifact input uv.lock does not cover.
+requires = ["hatchling>=1.25,<2"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Bounded: the build backend is the one artifact input uv.lock does not cover.
-requires = ["hatchling>=1.25,<2"]
+requires = ["hatchling>=1.27,<2"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## What
Publishes `agent-learning-kit` to PyPI via **Trusted Publishing (OIDC)** — no long-lived token — **on merge to `main`**, and updates the README Install section (which becomes the PyPI project page).

### `.github/workflows/publish-pypi.yml`
- **Trigger:** every push to `main` (i.e. every merged PR). No `workflow_dispatch`, no tag trigger.
- **`check` job:** reads the `pyproject` version (`uv version --short`) and looks it up on PyPI. **404 → release; 200 → skip cleanly** (ordinary merges stay green and never page the reviewer); anything else → fail rather than guess. Refuses any ref other than `main`.
- **`build` job** (only when releasing, holds no secrets): `uv build`, then a smoke install of the wheel that imports `fi.simulate.hosted.child_entrypoint` and `fi.alk.harness` and runs `alk --help`. `persist-credentials: false`.
- **`publish` job:** runs under the `pypi` environment → **pauses for a required reviewer** (self-review prevented) → publishes with `id-token: write` only; downloads + publishes, runs no repo code. `attestations: true` (PEP 740), `skip-existing: true`.
- All actions SHA-pinned; `setup-uv` held to 0.12.x; timeouts; `concurrency` serializes publishes and never cancels one mid-flight.

### `pyproject.toml`
`[build-system] requires = ["hatchling>=1.27,<2"]` — the build backend is the one artifact input `uv.lock` doesn't cover.

### `README.md`
Install leads with `pip install agent-learning-kit`; source install kept for contributors; all relative links/images made absolute (they'd 404 on pypi.org).

## How to release
Bump `version` in `pyproject.toml` (+ `uv lock`) → merge to `main` → approve the `pypi` deployment when it pauses. Each version publishes exactly once (PyPI is immutable); a mistake needs a new version.

## ⚠️ Merging this PR is the first release
`0.1.0` is not on PyPI, so the merge itself triggers `check → build → publish (waiting on reviewer)`. The reviewer's approval click **is** the `0.1.0` publish. The pending Trusted Publisher is registered (`future-agi` / `agent-learning-kit` / `publish-pypi.yml` / env `pypi`); it does not reserve the name, so approve promptly.

## Why
The hosted simulation-runner image bundles this SDK and installs it from PyPI (`Dockerfile.simulation-runner`); nothing has published it until now, which left the sim-runner release pipeline inert. Publishing (immutable) was chosen over shipping hand-built wheels (mutable, unverifiable).
